### PR TITLE
Turn some potentially dangerous templates into functions

### DIFF
--- a/json_rpc/jsonmarshal.nim
+++ b/json_rpc/jsonmarshal.nim
@@ -1,9 +1,9 @@
 import macros, json, options, typetraits
 
-template expect*(actual, expected: JsonNodeKind, argName: string) =
+proc expect*(actual, expected: JsonNodeKind, argName: string) =
   if actual != expected: raise newException(ValueError, "Parameter [" & argName & "] expected " & $expected & " but got " & $actual)
 
-template expectType*(actual: JsonNodeKind, expected: typedesc, argName: string, allowNull = false) =
+proc expectType*(actual: JsonNodeKind, expected: typedesc, argName: string, allowNull = false) =
   var expType: JsonNodeKind
   when expected is array:
     expType = JArray

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -59,7 +59,7 @@ proc clear*(router: var RpcRouter) = router.procs.clear
 
 proc hasMethod*(router: RpcRouter, methodName: string): bool = router.procs.hasKey(methodName)
 
-template isEmpty(node: JsonNode): bool = node.isNil or node.kind == JNull
+func isEmpty(node: JsonNode): bool = node.isNil or node.kind == JNull
 
 # Json state checking
 

--- a/tests/ethhexstrings.nim
+++ b/tests/ethhexstrings.nim
@@ -15,12 +15,14 @@ proc encodeQuantity*(value: SomeUnsignedInt): string =
   var hValue = value.toHex.stripLeadingZeros
   result = "0x" & hValue
 
-template hasHexHeader*(value: string | HexDataStr | HexQuantityStr): bool =
-  template strVal: untyped = value.string
+func hasHexHeader*(value: string): bool =
   if strVal != "" and strVal[0] == '0' and strVal[1] in {'x', 'X'} and strVal.len > 2: true
   else: false
 
-template isHexChar*(c: char): bool =
+template hasHexHeader*(value: HexDataStr|HexQuantityStr): bool =
+  value.string.hasHexHeader
+
+func isHexChar*(c: char): bool =
   if  c notin {'0'..'9'} and
       c notin {'a'..'f'} and
       c notin {'A'..'F'}: false


### PR DESCRIPTION
Be careful when creating templates. If the input parameters are
referenced within the body multiple times, this may lead to multiple
evaluations of functions with side-effects.