### PR TITLE
Fix tests not closing connections

### DIFF
--- a/json_rpc/servers/httpserver.nim
+++ b/json_rpc/servers/httpserver.nim
@@ -319,3 +319,8 @@ proc close*(server: RpcHttpServer) =
   ## Cleanup resources of RPC server.
   for item in server.servers:
     item.close()
+
+proc closeWait*(server: RpcHttpServer) {.async.} =
+  ## Cleanup resources of RPC server.
+  for item in server.servers:
+    await item.closeWait()

--- a/json_rpc/servers/socketserver.nim
+++ b/json_rpc/servers/socketserver.nim
@@ -147,3 +147,8 @@ proc close*(server: RpcSocketServer) =
   ## Cleanup resources of RPC server.
   for item in server.servers:
     item.close()
+
+proc closeWait*(server: RpcSocketServer) {.async.} =
+  ## Cleanup resources of RPC server.
+  for item in server.servers:
+    await item.closeWait()

--- a/tests/testerrors.nim
+++ b/tests/testerrors.nim
@@ -6,11 +6,11 @@
 import unittest, debugclient, ../json_rpc/rpcserver
 import strformat, chronicles
 
-var server = newRpcSocketServer("localhost", 8547.Port)
+var server = newRpcSocketServer("localhost", Port(8545))
 var client = newRpcSocketClient()
 
 server.start()
-waitFor client.connect("localhost", Port(8547))
+waitFor client.connect("localhost", Port(8545))
 
 server.rpc("rpc") do(a: int, b: int):
   result = %(&"a: {a}, b: {b}")

--- a/tests/testethcalls.nim
+++ b/tests/testethcalls.nim
@@ -74,4 +74,4 @@ suite "Generated from signatures":
     check sigResults[1] == "0x47173285A8D7341E5E972FC677286384F802F8EF42A5EC5F03BBFA254CB01FAD"
 
 server.stop()
-server.close()
+waitFor server.closeWait()

--- a/tests/testethcalls.nim
+++ b/tests/testethcalls.nim
@@ -7,7 +7,7 @@ from strutils import rsplit
 template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
 
 var
-  server = newRpcSocketServer("localhost", Port(8546))
+  server = newRpcSocketServer("localhost", Port(8545))
   client = newRpcSocketClient()
 
 ## Generate Ethereum server RPCs
@@ -49,7 +49,7 @@ proc testSigCalls: Future[seq[string]] =
   result = all(version, sha3)
 
 server.start()
-waitFor client.connect("localhost", Port(8546))
+waitFor client.connect("localhost", Port(8545))
 
 
 suite "Local calls":

--- a/tests/testhttp.nim
+++ b/tests/testhttp.nim
@@ -177,4 +177,4 @@ suite "HTTP Server/HTTP Client RPC test suite":
     check waitFor(disconTest("localhost", Port(8545), 7, 200)) == true
 
 httpsrv.stop()
-httpsrv.close()
+waitFor httpsrv.closeWait()

--- a/tests/testrpcmacro.nim
+++ b/tests/testrpcmacro.nim
@@ -157,4 +157,4 @@ suite "Server types":
     check r == %"hello world"
 
 s.stop()
-s.close()
+waitFor s.closeWait()

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -1,7 +1,7 @@
 import unittest, json, chronicles
 import  ../json_rpc/[rpcclient, rpcserver]
 
-var srv = newRpcSocketServer(["localhost:8546"])
+var srv = newRpcSocketServer(["localhost:8545"])
 var client = newRpcSocketClient()
 
 # Create RPC on server
@@ -9,7 +9,7 @@ srv.rpc("myProc") do(input: string, data: array[0..3, int]):
   result = %("Hello " & input & " data: " & $data)
 
 srv.start()
-waitFor client.connect("localhost", Port(8546))
+waitFor client.connect("localhost", Port(8545))
 
 # TODO: When an error occurs during a test, stop the server
 suite "Server/Client RPC":

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -1,7 +1,7 @@
 import unittest, json, chronicles
 import  ../json_rpc/[rpcclient, rpcserver]
 
-var srv = newRpcSocketServer(["localhost:8545"])
+var srv = newRpcSocketServer(["localhost:8546"])
 var client = newRpcSocketClient()
 
 # Create RPC on server
@@ -9,7 +9,7 @@ srv.rpc("myProc") do(input: string, data: array[0..3, int]):
   result = %("Hello " & input & " data: " & $data)
 
 srv.start()
-waitFor client.connect("localhost", Port(8545))
+waitFor client.connect("localhost", Port(8546))
 
 # TODO: When an error occurs during a test, stop the server
 suite "Server/Client RPC":

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -18,4 +18,4 @@ suite "Server/Client RPC":
     check r.result.getStr == "Hello abc data: [1, 2, 3, 4]"
 
 srv.stop()
-srv.close()
+waitFor srv.closeWait()


### PR DESCRIPTION
Connections are not closed immediately, and can result in the next test failing because the socket is in use.
This PR adds `closeWait` to the servers so that they can be waited on to ensure their connections are closed before the next test begins.