### PR TITLE
use HTTP1.0 and drop connection:keep-alive

### DIFF
--- a/json_rpc/clients/httpclient.nim
+++ b/json_rpc/clients/httpclient.nim
@@ -24,13 +24,12 @@ const
 proc sendRequest(transp: StreamTransport,
                  data: string, httpMethod: HttpMethod): Future[bool] {.async.} =
   var request = $httpMethod & " / "
-  request.add($HttpVersion11)
+  request.add($HttpVersion10)
   request.add("\r\n")
   request.add("Date: " & httpDate() & "\r\n")
   request.add("Host: " & $transp.remoteAddress & "\r\n")
   request.add("Content-Type: application/json\r\n")
   request.add("Content-Length: " & $len(data) & "\r\n")
-  request.add("Connection: keep-alive\r\n")
   request.add("\r\n")
   if len(data) > 0:
     request.add(data)

--- a/tests/testhttp.nim
+++ b/tests/testhttp.nim
@@ -60,12 +60,13 @@ const
 
 proc continuousTest(address: string, port: Port): Future[int] {.async.} =
   var client = newRpcHttpClient()
-  await client.connect(address, port)
   result = 0
   for i in 0..<TestsCount:
+    await client.connect(address, port)
     var r = await client.call("myProc", %[%"abc", %[1, 2, 3, i]])
     if r.result.getStr == "Hello abc data: [1, 2, 3, " & $i & "]":
       result += 1
+    client.transp.close()
 
 proc customMessage(address: TransportAddress,
                    data: string,


### PR DESCRIPTION
I remember we agree to use HTTP1.0
also I think commit 6a0b0ff30d602e59056d1558662667ae5700d09c won't work with HTTP1.1