### PR TITLE
support Content-Type headers with specified charset

### DIFF
--- a/json_rpc/servers/httpserver.nim
+++ b/json_rpc/servers/httpserver.nim
@@ -72,7 +72,8 @@ proc validateRequest(transp: StreamTransport,
     return
 
   var ctype = header["Content-Type"]
-  if ctype.toLowerAscii() != "application/json":
+  # might be "application/json; charset=utf-8"
+  if "application/json" notin ctype.toLowerAscii():
     # Content-Type header is not "application/json"
     debug "Content type must be application/json",
           address = transp.remoteAddress()


### PR DESCRIPTION
and add RPC message content to the debugging output (at the TRACE level,
disabled by default)

---
Bug found while trying to get Parity to work with Premix.