### PR TITLE
Check if method field is a string against unhandled exception

### DIFF
--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -90,7 +90,7 @@ proc checkJsonState*(line: string,
   let jVer = node{jsonRpcField}
   if jVer != nil and jVer.kind != JNull and jVer != %"2.0":
     return some((rjeVersionError, ""))
-  if not node.hasKey(methodField):
+  if not node.hasKey(methodField) or node[methodField].kind != JString:
     return some((rjeNoMethod, ""))
   if not node.hasKey(paramsField):
     return some((rjeNoParams, ""))


### PR DESCRIPTION
`FieldError` exception can occur [here](https://github.com/status-im/nim-json-rpc/blob/master/json_rpc/router.nim#L113) when a non string value is send for the json method member.

Would result in a crash for `socketserver`. `httpserver` would be fine due to its catch all code.