### PR TITLE
Added marshalling support for uint32

### DIFF
--- a/json_rpc/jsonmarshal.nim
+++ b/json_rpc/jsonmarshal.nim
@@ -34,6 +34,7 @@ proc fromJson*[T](n: JsonNode, argName: string, result: var seq[T])
 proc fromJson*[N, T](n: JsonNode, argName: string, result: var array[N, T])
 proc fromJson*(n: JsonNode, argName: string, result: var int64)
 proc fromJson*(n: JsonNode, argName: string, result: var uint64)
+proc fromJson*(n: JsonNode, argName: string, result: var uint32)
 proc fromJson*(n: JsonNode, argName: string, result: var ref int64)
 proc fromJson*(n: JsonNode, argName: string, result: var ref int)
 proc fromJson*[T](n: JsonNode, argName: string, result: var Option[T])
@@ -93,6 +94,16 @@ proc fromJson*(n: JsonNode, argName: string, result: var uint64) =
     raise newException(
       ValueError, "JSON-RPC input is an unexpected negative value")
   result = uint64(asInt)
+
+proc fromJson*(n: JsonNode, argName: string, result: var uint32) =
+  n.kind.expect(JInt, argName)
+  let asInt = n.getInt()
+  # signed -> unsigned conversions are unchecked
+  # https://github.com/nim-lang/RFCs/issues/175
+  if asInt < 0:
+    raise newException(
+      ValueError, "JSON-RPC input is an unexpected negative value")
+  result = uint32(asInt)
 
 proc fromJson*(n: JsonNode, argName: string, result: var ref int64) =
   n.kind.expect(JInt, argName)

--- a/json_rpc/jsonmarshal.nim
+++ b/json_rpc/jsonmarshal.nim
@@ -97,7 +97,7 @@ proc fromJson*(n: JsonNode, argName: string, result: var uint64) =
 
 proc fromJson*(n: JsonNode, argName: string, result: var uint32) =
   n.kind.expect(JInt, argName)
-  let asInt = n.getInt()
+  let asInt = n.getBiggestInt()
   # signed -> unsigned conversions are unchecked
   # https://github.com/nim-lang/RFCs/issues/175
   if asInt < 0:


### PR DESCRIPTION
Added support for uint32 marshalling as required for [Waku v2 API](https://github.com/status-im/nim-waku/issues/258).
See also [this pull request](https://github.com/status-im/nim-waku/pull/263#pullrequestreview-528496942) and discussion with @kdeme 
Thanks! :)