### PR TITLE
Add support for incoming messages with omitted params

### DIFF
--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -71,6 +71,9 @@ template jsonValid*(jsonString: string, node: var JsonNode): (bool, string) =
     msg = ""
   try:
     node = parseJson(line)
+    # Handle cases where params is omitted
+    if not node.hasKey(paramsField):
+        node.add(paramsField, newJArray())
   except CatchableError as exc:
     valid = false
     msg = exc.msg

--- a/tests/testhttp.nim
+++ b/tests/testhttp.nim
@@ -56,6 +56,13 @@ const
       "Connection: close\r\n" &
       "\r\n" &
       "{\"jsonrpc\":\"2.0\",\"method\":\"myProc\",\"params\":[\"abc\", [1, 2, 3]],\"id\":67}",
+    "GET / HTTP/1.1\r\n" &
+      "Host: www.google.com\r\n" &
+      "Content-Length: 49\r\n" &
+      "Content-Type: application/json\r\n" &
+      "Connection: close\r\n" &
+      "\r\n" &
+      "{\"jsonrpc\":\"2.0\",\"method\":\"noParamsProc\",\"id\":67}",
   ]
 
 proc continuousTest(address: string, port: Port): Future[int] {.async.} =
@@ -150,6 +157,8 @@ var httpsrv = newRpcHttpServer(["localhost:8545"])
 # Create RPC on server
 httpsrv.rpc("myProc") do(input: string, data: array[0..3, int]):
   result = %("Hello " & input & " data: " & $data)
+httpsrv.rpc("noParamsProc") do():
+  result = %("Hello world")
 
 httpsrv.start()
 
@@ -176,6 +185,8 @@ suite "HTTP Server/HTTP Client RPC test suite":
       waitFor(disconTest("localhost", Port(8545), 6, 200)) == true
   test "[Connection]: close test":
     check waitFor(disconTest("localhost", Port(8545), 7, 200)) == true
+  test "Omitted params test":
+    check waitFor(simpleTest("localhost", Port(8545), 8, 200)) == true
 
 httpsrv.stop()
 waitFor httpsrv.closeWait()


### PR DESCRIPTION
This is a fix for #93. The JSON-RPC 2.0 spec claims that in requests, the `params` field may be omitted if it's empty and several clients I've tried demonstrate that behavior. However, nim-json-rpc requires params to be present all of the time, even if it's empty. This prevents integrating with applications that omit the params field in requests.

My pull request here fixes that behavior with a simple check in `RpcRouter.jsonValid(...)` which will add an empty `params` field if one doesn't exist in the request. I also added a unit test to `testhttp.nim` to confirm this behavior works properly.

Some notes:
- This is my first time working in Nim, so while the unit tests work (and Nimbus can now talk to Rocket Pool), please make sure my modifications are up to your standards.
- While this works for `RpcRouter.route()`, I didn't change the code for `RpcRouter.tryRoute()` which looks like it will simply fail by design if the `params` field is empty. Not sure if that's relevant here.
- There are a lot of mentions in `README.md` and throughout the code that assume the `params` field has to be present. I didn't modify all of them because that's not really my place - I just wanted to let my clients talk to nim-json-rpc servers. A more thorough overhaul may be in order if this workaround feels like too much of a "hack".