### PR TITLE
[FEATURE] Add http json rpc proxy

### DIFF
--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -12,12 +12,8 @@ type
   # Procedure signature accepted as an RPC call by server
   RpcProc* = proc(input: JsonNode): Future[StringOfJson] {.gcsafe, raises: [Defect, CatchableError].}
 
-  # Procedure signature to call in case user does not register normal RpcProc handler
-  MissingMethodHandler* = proc(name: string, input: JsonNode): Future[JsonNode] {.gcsafe, raises: [Defect, CatchableError].}
-
   RpcRouter* = object
     procs*: Table[string, RpcProc]
-    missingMethodHandlers*: Table[string, MissingMethodHandler]
 
 const
   methodField = "method"
@@ -40,16 +36,10 @@ proc newRpcRouter*: RpcRouter {.deprecated.} =
 proc register*(router: var RpcRouter, path: string, call: RpcProc) =
   router.procs.add(path, call)
 
-proc registerMissingMethodHandler*(router: var RpcRouter, path: string, call: MissingMethodHandler) =
-  router.missingMethodHandlers.add(path, call)
-
 proc clear*(router: var RpcRouter) = 
   router.procs.clear
-  router.missingMethodHandlers.clear
 
 proc hasMethod*(router: RpcRouter, methodName: string): bool = router.procs.hasKey(methodName)
-
-proc hasMissingMethodHandler*(router: RpcRouter, methodName: string): bool = router.missingMethodHandlers.hasKey(methodName)
 
 func isEmpty(node: JsonNode): bool = node.isNil or node.kind == JNull
 
@@ -82,21 +72,10 @@ proc route*(router: RpcRouter, node: JsonNode): Future[StringOfJson] {.async, gc
     return wrapError(INVALID_REQUEST, "'method' missing or invalid")
 
   let rpcProc = router.procs.getOrDefault(methodName)
-  let missingMethodHandler = router.missingMethodHandlers.getOrDefault(methodName)
   let params = node.getOrDefault("params")
 
-  if rpcProc == nil and (missingMethodHandler == nil):
+  if rpcProc == nil:
     return wrapError(METHOD_NOT_FOUND, "'" & methodName & "' is not a registered RPC method", id)
-  elif rpcProc == nil and (missingMethodHandler != nil):
-    try:
-      let res = await missingMethodHandler(methodName, if params == nil: newJArray() else: params)
-      let asString = StringOfJson($res)
-      return wrapReply(id, asString)
-
-    except CatchableError as err:
-      debug "Error occurred within RPC", methodName = methodName, err = err.msg
-      return wrapError(
-        SERVER_ERROR, methodName & " raised an exception", id, newJString(err.msg))
   else:
     try:
       let res = await rpcProc(if params == nil: newJArray() else: params)

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -1,3 +1,5 @@
+{.push raises: [Defect].}
+
 import 
   ./servers/[httpserver],
   ./clients/[httpclient]
@@ -9,12 +11,12 @@ type RpcHttpProxy* = ref object of RootRef
 proc proxyCall(client: RpcHttpClient): ProxyCall =
   return proc (name: string, params: JsonNode): Future[Response] = client.call(name, params)
 
-proc new*(T: type RpcHttpProxy, listenAddresses: openArray[string]): T = 
+proc new*(T: type RpcHttpProxy, listenAddresses: openArray[string]): T {.raises: [Defect, CatchableError].}= 
   let client = newRpcHttpClient()
   let router = RpcRouter.init()
   T(rpcHttpClient: client, rpcHttpServer: newRpcHttpServer(listenAddresses, router))
 
-proc newRpcHttpProxy*(listenAddresses: openArray[string]): RpcHttpProxy =
+proc newRpcHttpProxy*(listenAddresses: openArray[string]): RpcHttpProxy {.raises: [Defect, CatchableError].} =
   RpcHttpProxy.new(listenAddresses)
 
 proc start*(proxy:RpcHttpProxy, proxyServerUrl: string) {.async.} =
@@ -28,10 +30,10 @@ proc start*(proxy:RpcHttpProxy, proxyServerAddress: string, proxyServerPort: Por
 template rpc*(server: RpcHttpProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 
-proc registerProxyMethod*(proxy: var RpcHttpProxy, methodName: string) = 
-  proxy.rpcHttpServer.registerProxyCall(methodName, proxyCall(proxy.rpcHttpClient))
+proc registerProxyMethod*(proxy: var RpcHttpProxy, methodName: string) {.raises: [Defect, CatchableError].} = 
+ proxy.rpcHttpServer.registerProxyCall(methodName, proxyCall(proxy.rpcHttpClient))
 
-proc stop*(rpcHttpProxy: RpcHttpProxy) =
+proc stop*(rpcHttpProxy: RpcHttpProxy) {.raises: [Defect, CatchableError].} =
   rpcHttpProxy.rpcHttpServer.stop()
 
 proc closeWait*(rpcHttpProxy: RpcHttpProxy) {.async.} =

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -1,38 +1,38 @@
-import servers/[socketserver, httpserver]
-import clients/[socketclient, httpclient]
+import 
+  ./servers/[httpserver],
+  ./clients/[httpclient]
 
 type RpcHttpProxy* = ref object of RootRef
-    rpcHttpClient: RpcHttpClient
-    rpcHttpServer: RpcHttpServer
+  rpcHttpClient: RpcHttpClient
+  rpcHttpServer: RpcHttpServer
 
 proc proxyCall(client: RpcHttpClient): ProxyCall =
-  result = 
-    proc (name: string, params: JsonNode): Future[Response] = client.call(name, params)
+  return proc (name: string, params: JsonNode): Future[Response] = client.call(name, params)
 
 proc new*(T: type RpcHttpProxy, listenAddresses: openArray[string]): T = 
-    let client = newRpcHttpClient()
-    let router = RpcRouter.init()
-    T(rpcHttpClient: client, rpcHttpServer: newRpcHttpServer(listenAddresses, router))
+  let client = newRpcHttpClient()
+  let router = RpcRouter.init()
+  T(rpcHttpClient: client, rpcHttpServer: newRpcHttpServer(listenAddresses, router))
 
 proc newRpcHttpProxy*(listenAddresses: openArray[string]): RpcHttpProxy =
-    RpcHttpProxy.new(listenAddresses)
+  RpcHttpProxy.new(listenAddresses)
 
-proc init*(proxy:RpcHttpProxy, proxyServerUrl: string) {.async.} =
-    proxy.rpcHttpServer.start()
-    await proxy.rpcHttpClient.connect(proxyServerUrl)
+proc start*(proxy:RpcHttpProxy, proxyServerUrl: string) {.async.} =
+  proxy.rpcHttpServer.start()
+  await proxy.rpcHttpClient.connect(proxyServerUrl)
 
-proc init*(proxy:RpcHttpProxy, proxyServerAddress: string, proxyServerPort: Port) {.async.} =
-    proxy.rpcHttpServer.start()
-    await proxy.rpcHttpClient.connect(proxyServerAddress, proxyServerPort)
+proc start*(proxy:RpcHttpProxy, proxyServerAddress: string, proxyServerPort: Port) {.async.} =
+  proxy.rpcHttpServer.start()
+  await proxy.rpcHttpClient.connect(proxyServerAddress, proxyServerPort)
 
 template rpc*(server: RpcHttpProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 
-proc registerProxyMethod*(proxy: var RpcHttpProxy, methodName: string) =
-    proxy.rpcHttpServer.registerProxyCall(methodName, proxyCall(proxy.rpcHttpClient))
+proc registerProxyMethod*(proxy: var RpcHttpProxy, methodName: string) = 
+  proxy.rpcHttpServer.registerProxyCall(methodName, proxyCall(proxy.rpcHttpClient))
 
 proc stop*(rpcHttpProxy: RpcHttpProxy) =
-    rpcHttpProxy.rpcHttpServer.stop()
+  rpcHttpProxy.rpcHttpServer.stop()
 
 proc closeWait*(rpcHttpProxy: RpcHttpProxy) {.async.} =
-    await rpcHttpProxy.rpcHttpServer.closeWait()
+  await rpcHttpProxy.rpcHttpServer.closeWait()

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -32,8 +32,12 @@ proc start*(proxy:RpcHttpProxy, proxyServerAddress: string, proxyServerPort: Por
 template rpc*(server: RpcHttpProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 
-proc registerProxyMethod*(proxy: var RpcHttpProxy, methodName: string) {.raises: [Defect, CatchableError].} = 
- proxy.rpcHttpServer.register(methodName, proxyCall(proxy.rpcHttpClient, methodName))
+proc registerProxyMethod*(proxy: var RpcHttpProxy, methodName: string) =
+  try:
+    proxy.rpcHttpServer.register(methodName, proxyCall(proxy.rpcHttpClient, methodName))
+  except CatchableError as err:
+    # Adding proc type to table gives invalid exception tracking, see Nim bug: https://github.com/nim-lang/Nim/issues/18376
+    raiseAssert err.msg
 
 proc stop*(rpcHttpProxy: RpcHttpProxy) {.raises: [Defect, CatchableError].} =
   rpcHttpProxy.rpcHttpServer.stop()

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -8,7 +8,7 @@ type RpcHttpProxy* = ref object of RootRef
   rpcHttpClient: RpcHttpClient
   rpcHttpServer: RpcHttpServer
 
-proc proxyCall(client: RpcHttpClient): ProxyCall =
+proc proxyCall(client: RpcHttpClient): MissingMethodHandler =
   return proc (name: string, params: JsonNode): Future[Response] = client.call(name, params)
 
 proc new*(T: type RpcHttpProxy, listenAddresses: openArray[string]): T {.raises: [Defect, CatchableError].}= 
@@ -31,7 +31,7 @@ template rpc*(server: RpcHttpProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 
 proc registerProxyMethod*(proxy: var RpcHttpProxy, methodName: string) {.raises: [Defect, CatchableError].} = 
- proxy.rpcHttpServer.registerProxyCall(methodName, proxyCall(proxy.rpcHttpClient))
+ proxy.rpcHttpServer.registerMissingMethodHandler(methodName, proxyCall(proxy.rpcHttpClient))
 
 proc stop*(rpcHttpProxy: RpcHttpProxy) {.raises: [Defect, CatchableError].} =
   rpcHttpProxy.rpcHttpServer.stop()

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -1,0 +1,36 @@
+import servers/[socketserver, httpserver]
+import clients/[socketclient, httpclient]
+
+type RpcHttpProxy* = ref object of RootRef
+    rpcHttpClient: RpcHttpClient
+    rpcHttpServer: RpcHttpServer
+
+proc proxyCall(client: RpcHttpClient): RecoveryProc =
+  result = 
+    proc (name: string, params: JsonNode): Future[Response] = client.call(name, params)
+
+proc new*(T: type RpcHttpProxy, listenAddresses: openArray[string]): T = 
+    let client = newRpcHttpClient()
+    let proxyCall = proxyCall(client)
+    let router = RpcRouter.init(proxyCall)
+    T(rpcHttpClient: client, rpcHttpServer: newRpcHttpServer(listenAddresses, router))
+
+proc newRpcHttpProxy*(listenAddresses: openArray[string]): RpcHttpProxy =
+    RpcHttpProxy.new(listenAddresses)
+
+proc init*(proxy:RpcHttpProxy, proxyServerUrl: string) {.async.} =
+    proxy.rpcHttpServer.start()
+    await proxy.rpcHttpClient.connect(proxyServerUrl)
+
+proc init*(proxy:RpcHttpProxy, proxyServerAddress: string, proxyServerPort: Port) {.async.} =
+    proxy.rpcHttpServer.start()
+    await proxy.rpcHttpClient.connect(proxyServerAddress, proxyServerPort)
+
+template rpc*(server: RpcHttpProxy, path: string, body: untyped): untyped =
+  server.rpcHttpServer.rpc(path, body)
+
+proc stop*(rpcHttpProxy: RpcHttpProxy) =
+    rpcHttpProxy.rpcHttpServer.stop()
+
+proc closeWait*(rpcHttpProxy: RpcHttpProxy) {.async.} =
+    await rpcHttpProxy.rpcHttpServer.closeWait()

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -31,6 +31,10 @@ proc register*(server: RpcServer, name: string, rpc: RpcProc) =
   ## Add a name/code pair to the RPC server.
   server.router.register(name, rpc)
 
+proc registerProxyCall*(server: RpcServer, name: string, proxyCall: ProxyCall) =
+  ## Add alternative path for name/code pair handling to the RPC server.
+  server.router.registerProxy(name, proxyCall)
+
 proc unRegisterAll*(server: RpcServer) =
   # Remove all remote procedure calls from this server.
   server.router.clear

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -31,9 +31,9 @@ proc register*(server: RpcServer, name: string, rpc: RpcProc) =
   ## Add a name/code pair to the RPC server.
   server.router.register(name, rpc)
 
-proc registerProxyCall*(server: RpcServer, name: string, proxyCall: ProxyCall) =
+proc registerMissingMethodHandler*(server: RpcServer, name: string, proxyCall: MissingMethodHandler) =
   ## Add alternative path for name/code pair handling to the RPC server.
-  server.router.registerProxy(name, proxyCall)
+  server.router.registerMissingMethodHandler(name, proxyCall)
 
 proc unRegisterAll*(server: RpcServer) =
   # Remove all remote procedure calls from this server.

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -31,10 +31,6 @@ proc register*(server: RpcServer, name: string, rpc: RpcProc) =
   ## Add a name/code pair to the RPC server.
   server.router.register(name, rpc)
 
-proc registerMissingMethodHandler*(server: RpcServer, name: string, proxyCall: MissingMethodHandler) =
-  ## Add alternative path for name/code pair handling to the RPC server.
-  server.router.registerMissingMethodHandler(name, proxyCall)
-
 proc unRegisterAll*(server: RpcServer) =
   # Remove all remote procedure calls from this server.
   server.router.clear

--- a/json_rpc/servers/httpserver.nim
+++ b/json_rpc/servers/httpserver.nim
@@ -299,8 +299,14 @@ proc addStreamServer*(server: RpcHttpServer, address: string, port: Port) =
 proc new*(T: type RpcHttpServer): T =
   T(router: RpcRouter.init(), servers: @[])
 
+proc new*(T: type RpcHttpServer, router: RpcRouter): T =
+  T(router: router, servers: @[])
+
 proc newRpcHttpServer*(): RpcHttpServer =
   RpcHttpServer.new()
+
+proc newRpcHttpServer*(router: RpcRouter): RpcHttpServer =
+  RpcHttpServer.new(router)
 
 proc newRpcHttpServer*(addresses: openArray[TransportAddress]): RpcHttpServer =
   ## Create new server and assign it to addresses ``addresses``.
@@ -310,6 +316,11 @@ proc newRpcHttpServer*(addresses: openArray[TransportAddress]): RpcHttpServer =
 proc newRpcHttpServer*(addresses: openArray[string]): RpcHttpServer =
   ## Create new server and assign it to addresses ``addresses``.
   result = newRpcHttpServer()
+  result.addStreamServers(addresses)
+
+proc newRpcHttpServer*(addresses: openArray[string], router: RpcRouter): RpcHttpServer =
+  ## Create new server and assign it to addresses ``addresses``.
+  result = newRpcHttpServer(router)
   result.addStreamServers(addresses)
 
 proc start*(server: RpcHttpServer) =

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -1,4 +1,4 @@
 {. warning[UnusedImport]:off .}
 
 import
-  testrpcmacro, testserverclient, testethcalls, testhttp
+  testrpcmacro, testserverclient, testethcalls, testhttp, testproxy

--- a/tests/testproxy.nim
+++ b/tests/testproxy.nim
@@ -9,17 +9,29 @@ let proxySrvAddress = "localhost:8546"
 var proxy = newRpcHttpProxy([proxySrvAddress])
 
 var client = newRpcHttpClient()
+let duplicatedProcedureName = "duplicated"
 
 # Create RPC on server
 srv.rpc("myProc") do(input: string, data: array[0..3, int]):
   return %("Hello " & input & " data: " & $data)
 
+# registration of duplicated procedures needs to happen in separate scope as otherwise macro does not compile, due
+# to redefinition of procedure name in scope (even if it happens on two different objects)
+block:
+  srv.rpc(duplicatedProcedureName) do()-> string:
+    return "server"
+
 # Create RPC on proxy server
 proxy.registerProxyMethod("myProc")
+proxy.registerProxyMethod(duplicatedProcedureName)
 
 # Create standard handler on server
 proxy.rpc("myProc1") do(input: string, data: array[0..3, int]):
   return %("Hello " & input & " data: " & $data)
+
+block:
+  proxy.rpc(duplicatedProcedureName) do()-> string:
+    return "proxy"
 
 srv.start()
 waitFor proxy.start("localhost", Port(8545))
@@ -32,6 +44,9 @@ suite "Proxy RPC":
   test "Successful RPC call no proxy":
     let r = waitFor client.call("myProc1", %[%"abc", %[1, 2, 3, 4]])
     check r.getStr == "Hello abc data: [1, 2, 3, 4]"
+  test "Call local method instead of proxy in case of conflict":
+    let r = waitFor client.call("duplicated", %[])
+    check r.getStr == "proxy"
   test "Missing params":
     expect(CatchableError):
       discard waitFor client.call("myProc", %[%"abc"])

--- a/tests/testproxy.nim
+++ b/tests/testproxy.nim
@@ -15,6 +15,9 @@ srv.rpc("myProc") do(input: string, data: array[0..3, int]):
   return %("Hello " & input & " data: " & $data)
 
 # Create RPC on proxy server
+proxy.registerProxyMethod("myProc")
+
+# Create standard handler on server
 proxy.rpc("myProc1") do(input: string, data: array[0..3, int]):
   return %("Hello " & input & " data: " & $data)
 

--- a/tests/testproxy.nim
+++ b/tests/testproxy.nim
@@ -1,0 +1,43 @@
+import
+  unittest, json, chronicles,
+  ../json_rpc/[rpcclient, rpcserver, rpcproxy]
+
+let srvAddress = "localhost:8545"
+var srv = newRpcHttpServer([srvAddress])
+
+let proxySrvAddress = "localhost:8546"
+var proxy = newRpcHttpProxy([proxySrvAddress])
+
+var client = newRpcHttpClient()
+
+# Create RPC on server
+srv.rpc("myProc") do(input: string, data: array[0..3, int]):
+  return %("Hello " & input & " data: " & $data)
+
+# Create RPC on proxy server
+proxy.rpc("myProc1") do(input: string, data: array[0..3, int]):
+  return %("Hello " & input & " data: " & $data)
+
+srv.start()
+waitFor proxy.init("localhost", Port(8545))
+waitFor client.connect("localhost", Port(8546))
+
+suite "Proxy RPC":
+  test "Successful RPC call thorugh proxy":
+    let r = waitFor client.call("myProc", %[%"abc", %[1, 2, 3, 4]])
+    check r.getStr == "Hello abc data: [1, 2, 3, 4]"
+  test "Successful RPC call no proxy":
+    let r = waitFor client.call("myProc1", %[%"abc", %[1, 2, 3, 4]])
+    check r.getStr == "Hello abc data: [1, 2, 3, 4]"
+  test "Missing params":
+    expect(CatchableError):
+      discard waitFor client.call("myProc", %[%"abc"])
+  test "Method missing on server and proxy server":
+    expect(CatchableError):
+      discard waitFor client.call("missingMethod", %[%"abc"])
+  
+
+srv.stop()
+waitFor srv.closeWait()
+proxy.stop()
+waitFor proxy.closeWait()

--- a/tests/testproxy.nim
+++ b/tests/testproxy.nim
@@ -22,7 +22,7 @@ proxy.rpc("myProc1") do(input: string, data: array[0..3, int]):
   return %("Hello " & input & " data: " & $data)
 
 srv.start()
-waitFor proxy.init("localhost", Port(8545))
+waitFor proxy.start("localhost", Port(8545))
 waitFor client.connect("localhost", Port(8546))
 
 suite "Proxy RPC":

--- a/tests/testproxy.nim
+++ b/tests/testproxy.nim
@@ -15,23 +15,12 @@ let duplicatedProcedureName = "duplicated"
 srv.rpc("myProc") do(input: string, data: array[0..3, int]):
   return %("Hello " & input & " data: " & $data)
 
-# registration of duplicated procedures needs to happen in separate scope as otherwise macro does not compile, due
-# to redefinition of procedure name in scope (even if it happens on two different objects)
-block:
-  srv.rpc(duplicatedProcedureName) do()-> string:
-    return "server"
-
 # Create RPC on proxy server
 proxy.registerProxyMethod("myProc")
-proxy.registerProxyMethod(duplicatedProcedureName)
 
 # Create standard handler on server
 proxy.rpc("myProc1") do(input: string, data: array[0..3, int]):
   return %("Hello " & input & " data: " & $data)
-
-block:
-  proxy.rpc(duplicatedProcedureName) do()-> string:
-    return "proxy"
 
 srv.start()
 waitFor proxy.start("localhost", Port(8545))
@@ -44,9 +33,6 @@ suite "Proxy RPC":
   test "Successful RPC call no proxy":
     let r = waitFor client.call("myProc1", %[%"abc", %[1, 2, 3, 4]])
     check r.getStr == "Hello abc data: [1, 2, 3, 4]"
-  test "Call local method instead of proxy in case of conflict":
-    let r = waitFor client.call("duplicated", %[])
-    check r.getStr == "proxy"
   test "Missing params":
     expect(CatchableError):
       discard waitFor client.call("myProc", %[%"abc"])


### PR DESCRIPTION
Add possibility to create proxies by adding recovery proc to router.

Advantages of this approach:
- no need for serialization/deserialization of arguments and results
- can easy be adapted to different transports
- can be used for other means

Disadvantages:
- obscures a control flow a little bit
- not easy to decide about error control flow i.e should router handle errors thrown by recovery procdure (I went with this), or procedure should handle errors it self

Nim related questions:
- Is passing procedures around considered good nim style ?
- Is using `Optional` types considered good style ? 
- Can `Future` throw exceptions ? In `scala` world `Futures` does not throw exceptions and in its finished state they can be in either `success` state or `failed` state.

Projects related questions:
- From what i see we do not have `https` client yet ( correct me if I am wrong). This is kinda problematic, as infura currently forces `https` connections on all requests, so If we would like to use proxy to call infura we would need to implements https support. (or use websockets if we have such option)

