### PR TITLE
fixes ws rpc client bug: error when trying to connect to infura

### DIFF
--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -78,16 +78,10 @@ proc connect*(client: RpcWebSocketClient, uri: string,
                              else:
                                @[]
   let uri = parseUri(uri)
-  let secure = uri.scheme == "wss"
-  let port = parseInt(uri.port)
-
   let ws = await WebSocket.connect(
-    host = uri.hostname,
-    port = Port(port),
-    path = uri.path,
-    secure=secure,
-    flags=flags,
-    factories=ext
+    uri=uri,
+    factories=ext,
+    flags=flags
   )
   client.transport = ws
   client.uri = uri


### PR DESCRIPTION
fixes #109

previously, if using uri such as "wss://mainnet.infura.io/ws/v3/project_id",
the client will throw error. this bug already fixed in nim-websock,
now this also fixed in json-rpc. it works when connected to infura wss.


Sorry no actual test because I have no idea how to write a test for this case.
The following snippet will produce infura client version string. Please replace the "project_id" with your infura project_id.

```Nim
import json_rpc/clients/websocketclient
import chronos, json

proc main() {.async.} =
  let client = RpcWebSocketClient.new()
  await client.connect("wss://mainnet.infura.io/ws/v3/project_id")
  let n = await client.call("web3_clientVersion", %[])
  debugEcho n


waitFor main()
```

```bash
"Geth/v1.10.2-omnibus-b8e4bcfc/linux-amd64/go1.16.3"
```