### PR TITLE
Restore the support for using the news package

### DIFF
--- a/json_rpc.nimble
+++ b/json_rpc.nimble
@@ -13,7 +13,8 @@ requires "nim >= 1.2.0",
          "chronos",
          "httputils",
          "chronicles#ba2817f1",
-         "https://github.com/status-im/nim-websock",
+         "https://github.com/status-im/news#status",
+         "websock",
          "json_serialization"
 
 proc getLang(): string =
@@ -29,6 +30,11 @@ proc buildBinary(name: string, srcDir = "./", params = "", cmdParams = "", lang 
 
 task test, "run tests":
   buildBinary "all", "tests/",
-    params = "-r -f --hints:off --debuginfo --path:'.' --threads:on -d:chronicles_log_level=ERROR",
+    params = "-r -f --hints:off --debuginfo --path:'.' --threads:on -d:chronicles_log_level=ERROR -d:json_rpc_websocket_package=websock",
+    cmdParams = "",
+    lang = getLang()
+
+  buildBinary "all", "tests/",
+    params = "-r -f --hints:off --debuginfo --path:'.' --threads:on -d:chronicles_log_level=ERROR -d:json_rpc_websocket_package=news",
     cmdParams = "",
     lang = getLang()

--- a/json_rpc/clients/config.nim
+++ b/json_rpc/clients/config.nim
@@ -1,0 +1,7 @@
+const
+  json_rpc_websocket_package {.strdefine.} = "websock"
+  useNews* = json_rpc_websocket_package == "news"
+
+when json_rpc_websocket_package notin ["websock", "news"]:
+  {.fatal: "json_rpc_websocket_package should be set to either 'websock' or 'news'".}
+

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -42,7 +42,7 @@ proc getWebSocketClientConfig*(
               flags: set[TLSFlags] = {
                 NoVerifyHost, NoVerifyServerName}): ClientConfig =
   ClientConfig(kind: WebSocket, wsUri: uri, compression: compression, flags: flags)
-    
+
 proc proxyCall(client: RpcClient, name: string): RpcProc =
   return proc (params: JsonNode): Future[StringOfJson] {.async.} =
           let res = await client.call(name, params)
@@ -63,14 +63,14 @@ proc new*(T: type RpcProxy, server: RpcHttpServer, cfg: ClientConfig): T =
   of WebSocket:
     let client = newRpcWebSocketClient()
     return T(
-              rpcHttpServer: server, 
-              kind: WebSocket, 
-              wsUri: cfg.wsUri, 
-              webSocketClient: client, 
-              compression: cfg.compression, 
+              rpcHttpServer: server,
+              kind: WebSocket,
+              wsUri: cfg.wsUri,
+              webSocketClient: client,
+              compression: cfg.compression,
               flags: cfg.flags
             )
- 
+
 proc new*(T: type RpcProxy, listenAddresses: openArray[TransportAddress], cfg: ClientConfig): T {.raises: [Defect, CatchableError].} =
   RpcProxy.new(newRpcHttpServer(listenAddresses, RpcRouter.init()), cfg)
 

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -1,4 +1,16 @@
 {. warning[UnusedImport]:off .}
 
 import
-  testrpcmacro, testserverclient, testethcalls, testhttp, testproxy
+  ../json_rpc/clients/config
+
+import
+  testrpcmacro, testethcalls, testhttp
+
+when not useNews:
+  # TODO The websock server doesn't interop properly
+  #      with the news client at the moment
+  import testserverclient
+
+when not useNews:
+  # The proxy implementation is based on websock
+  import testproxy

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -1,6 +1,9 @@
 import
   unittest, json, chronicles,
-  ../json_rpc/[rpcclient, rpcserver]
+  ../json_rpc/[rpcclient, rpcserver, clients/config]
+
+const
+  compressionSupported = useNews
 
 # Create RPC on server
 proc setupServer*(srv: RpcServer) =
@@ -57,12 +60,14 @@ suite "Websocket Server/Client RPC":
   waitFor srv.closeWait()
 
 suite "Websocket Server/Client RPC with Compression":
-  var srv = newRpcWebSocketServer("127.0.0.1", Port(8545), compression = true)
+  var srv = newRpcWebSocketServer("127.0.0.1", Port(8545),
+                                  compression = compressionSupported)
   var client = newRpcWebSocketClient()
 
   srv.setupServer()
   srv.start()
-  waitFor client.connect("ws://127.0.0.1:8545/", compression = true)
+  waitFor client.connect("ws://127.0.0.1:8545/",
+                         compression = compressionSupported)
 
   test "Successful RPC call":
     let r = waitFor client.call("myProc", %[%"abc", %[1, 2, 3, 4]])


### PR DESCRIPTION
Since the news client is only required as a stopgap solution for nimbus-eth2, the following issue that was discovered during the development of this PR is not addressed yet:

https://github.com/status-im/nim-json-rpc/issues/117