### PR TITLE
Remove version pin on chronicles

### DIFF
--- a/json_rpc.nimble
+++ b/json_rpc.nimble
@@ -12,7 +12,7 @@ requires "nim >= 1.2.0",
          "stint",
          "chronos",
          "httputils",
-         "chronicles#ba2817f1",
+         "chronicles",
          "https://github.com/status-im/news#status",
          "websock",
          "json_serialization"


### PR DESCRIPTION
Caused dependency conflicts when combining json_rpc with other
packages that depend on chronicles, now that chronicles has
a new version (0.10.2).

Requires https://github.com/status-im/nim-websock/pull/97 to be merged first.