### PR TITLE
Add support for two-way communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# Ignore all files without extensions (unix executable files)
-*
-!*.*
-!*/
-
 # Ignore all binary outputs
 *.so
 *.dylib
@@ -16,5 +11,3 @@ nimcache/
 
 # Ignore editor settings
 .vscode
-
-

--- a/README.md
+++ b/README.md
@@ -346,8 +346,7 @@ waitFor client.connect("localhost", Port(8545))
 
 let response = waitFor client.call("hello", %[%"Daisy"])
 
-# the call returns a `Response` type which contains the result
-echo response.result
+echo response
 ```
 
 ### `createRpcSigs`

--- a/json_rpc.nimble
+++ b/json_rpc.nimble
@@ -15,6 +15,8 @@ requires "nim >= 1.2.0",
          "chronicles",
          "https://github.com/status-im/news#status",
          "websock",
+         "asynctools",
+         "faststreams",
          "json_serialization"
 
 proc buildBinary(name: string, srcDir = "./", params = "", cmdParams = "") =
@@ -24,7 +26,10 @@ proc buildBinary(name: string, srcDir = "./", params = "", cmdParams = "") =
 
 task test, "run tests":
   buildBinary "all", "tests/",
-    params = "-d:json_rpc_websocket_package=websock"
+    params = "-d:json_rpc_websocket_package=websock -d:asyncBackend=chronos"
 
   buildBinary "all", "tests/",
-    params = "-d:json_rpc_websocket_package=news"
+    params = "-d:json_rpc_websocket_package=news -d:asyncBackend=chronos"
+
+  buildBinary "teststreamconnection", "tests/",
+    params = "-d:asyncBackend=asyncdispatch"

--- a/json_rpc.nimble.cfg
+++ b/json_rpc.nimble.cfg
@@ -1,0 +1,2 @@
+--define:"async_backend=asyncdispatch"
+--threads:on

--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -1,12 +1,12 @@
 import
   std/[tables, macros],
-  chronos,
+  faststreams/async_backend,
   ./jsonmarshal
 
 from strutils import toLowerAscii, replace
 
 export
-  chronos, jsonmarshal, tables
+  jsonmarshal, tables
 
 type
   ClientId* = int64
@@ -26,13 +26,16 @@ proc getNextId*(client: RpcClient): ClientId =
 proc rpcCallNode*(path: string, params: JsonNode, id: ClientId): JsonNode =
   %{"jsonrpc": %"2.0", "method": %path, "params": params, "id": %id}
 
+proc rpcNotificationNode*(path: string, params: JsonNode): JsonNode =
+  %{"jsonrpc": %"2.0", "method": %path, "params": params}
+
 method call*(client: RpcClient, name: string,
              params: JsonNode): Future[Response] {.
-    base, async, gcsafe, raises: [Defect, CatchableError].} =
+    base, async, gcsafe, raises: [Defect, CatchableError, Exception].} =
   discard
 
 method close*(client: RpcClient): Future[void] {.
-    base, async, gcsafe, raises: [Defect, CatchableError].} =
+    base, async, gcsafe, raises: [Defect, CatchableError, Exception].} =
   discard
 
 template `or`(a: JsonNode, b: typed): JsonNode =

--- a/json_rpc/clients/httpclient.nim
+++ b/json_rpc/clients/httpclient.nim
@@ -1,5 +1,5 @@
 import
-  std/[strutils, tables, uri],
+  std/[tables, uri],
   stew/[byteutils, results],
   chronos/apps/http/httpclient as chronosHttpClient,
   chronicles, httputils, json_serialization/std/net,

--- a/json_rpc/clients/socketclient.nim
+++ b/json_rpc/clients/socketclient.nim
@@ -3,7 +3,7 @@ import
   chronos,
   ../client
 
-export client
+export client, chronos
 
 type
   RpcSocketClient* = ref object of RpcClient

--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -1,7 +1,6 @@
 import
-  std/[strtabs, tables],
+  std/[tables],
   pkg/[chronos, chronicles],
-  stew/byteutils,
   ../client, ./config
 
 export client
@@ -21,6 +20,7 @@ when useNews:
 
 else:
   import std/[uri, strutils]
+  import stew/byteutils
   import pkg/websock/[websock, extensions/compression/deflate]
 
   type

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -1,19 +1,21 @@
 import
-  std/[macros, options, strutils, tables],
-  chronicles, chronos, json_serialization/writer,
+  std/[macros, options, strutils, tables], sugar,
+  chronicles, faststreams/async_backend, json_serialization/writer,
   ./jsonmarshal, ./errors
 
-export
-  chronos, jsonmarshal
+export jsonmarshal
 
 type
   StringOfJson* = JsonString
 
+  RpcResult* = Option[JsonString]
+
   # Procedure signature accepted as an RPC call by server
-  RpcProc* = proc(input: JsonNode): Future[StringOfJson] {.gcsafe, raises: [Defect, CatchableError].}
+  RpcProc* = proc(input: JsonNode): Future[RpcResult] {.gcsafe, raises: [Defect, CatchableError, Exception].}
 
   RpcRouter* = object
     procs*: Table[string, RpcProc]
+    fullParams*: bool # if false send "params" to the handlers
 
 const
   methodField = "method"
@@ -34,7 +36,7 @@ proc newRpcRouter*: RpcRouter {.deprecated.} =
   RpcRouter.init()
 
 proc register*(router: var RpcRouter, path: string, call: RpcProc) =
-  router.procs.add(path, call)
+  router.procs[path] = call
 
 proc clear*(router: var RpcRouter) =
   router.procs.clear
@@ -59,48 +61,57 @@ proc wrapError*(code: int, msg: string, id: JsonNode = newJNull(),
       $id, $code, escapeJson(msg), $data
     ] & "\r\n")
 
-proc route*(router: RpcRouter, node: JsonNode): Future[StringOfJson] {.async, gcsafe.} =
+proc hasReturnType(params: NimNode): bool =
+  if params != nil and params.len > 0 and params[0] != nil and
+    params[0].kind != nnkEmpty:
+    result = true
+
+proc route*(router: RpcRouter, node: JsonNode): Future[RpcResult] {.async, gcsafe.} =
   if node{"jsonrpc"}.getStr() != "2.0":
-    return wrapError(INVALID_REQUEST, "'jsonrpc' missing or invalid")
+    return some(wrapError(INVALID_REQUEST, "'jsonrpc' missing or invalid"))
 
   let id = node{"id"}
-  if id == nil:
-    return wrapError(INVALID_REQUEST, "'id' missing or invalid")
 
   let methodName = node{"method"}.getStr()
   if methodName.len == 0:
-    return wrapError(INVALID_REQUEST, "'method' missing or invalid")
+    return some(wrapError(INVALID_REQUEST, "'method' missing or invalid"))
 
   let rpcProc = router.procs.getOrDefault(methodName)
-  let params = node.getOrDefault("params")
 
   if rpcProc == nil:
-    return wrapError(METHOD_NOT_FOUND, "'" & methodName & "' is not a registered RPC method", id)
+    return some(wrapError(METHOD_NOT_FOUND, "'" & methodName & "' is not a registered RPC method", id))
   else:
     try:
+      let params = if router.fullParams:
+          node
+        else:
+          node.getOrDefault("params")
+
       let res = await rpcProc(if params == nil: newJArray() else: params)
-      return wrapReply(id, res)
+
+      return res.map((s) => wrapReply(id, s));
     except InvalidRequest as err:
-      return wrapError(err.code, err.msg)
+      debug "Error occurred within RPC", methodName = methodName, err = err.msg
+      return some(wrapError(err.code, err.msg))
     except CatchableError as err:
       debug "Error occurred within RPC", methodName = methodName, err = err.msg
-      return wrapError(
-        SERVER_ERROR, methodName & " raised an exception", id, newJString(err.msg))
+      return some(wrapError(
+        SERVER_ERROR, methodName & " raised an exception", id, newJString(err.msg)))
 
-proc route*(router: RpcRouter, data: string): Future[string] {.async, gcsafe.} =
+proc route*(router: RpcRouter, data: string): Future[RpcResult] {.async, gcsafe.} =
   ## Route to RPC from string data. Data is expected to be able to be converted to Json.
   ## Returns string of Json from RPC result/error node
   let node =
     try: parseJson(data)
     except CatchableError as err:
-      return string(wrapError(JSON_PARSE_ERROR, err.msg))
+      return some(wrapError(JSON_PARSE_ERROR, err.msg))
     except Exception as err:
       # TODO https://github.com/status-im/nimbus-eth2/issues/2430
-      return string(wrapError(JSON_PARSE_ERROR, err.msg))
+      return some(wrapError(JSON_PARSE_ERROR, err.msg))
 
-  return string(await router.route(node))
+  return await router.route(node);
 
-proc tryRoute*(router: RpcRouter, data: JsonNode, fut: var Future[StringOfJson]): bool =
+proc tryRoute*(router: RpcRouter, data: JsonNode, fut: var Future[RpcResult]): bool =
   ## Route to RPC, returns false if the method or params cannot be found.
   ## Expects json input and returns json output.
   let
@@ -115,16 +126,6 @@ proc tryRoute*(router: RpcRouter, data: JsonNode, fut: var Future[StringOfJson])
   if rpc != nil:
     fut = rpc(jParams)
     return true
-
-proc makeProcName(s: string): string =
-  result = ""
-  for c in s:
-    if c.isAlphaNumeric: result.add c
-
-proc hasReturnType(params: NimNode): bool =
-  if params != nil and params.len > 0 and params[0] != nil and
-     params[0].kind != nnkEmpty:
-    result = true
 
 macro rpc*(server: RpcRouter, path: string, body: untyped): untyped =
   ## Define a remote procedure call.
@@ -159,16 +160,16 @@ macro rpc*(server: RpcRouter, path: string, body: untyped): untyped =
   if ReturnType == ident"JsonNode":
     # `JsonNode` results don't need conversion
     result.add quote do:
-      proc `rpcProcWrapper`(`paramsIdent`: JsonNode): Future[StringOfJson] {.async, gcsafe.} =
-        return StringOfJson($(await `rpcProcImpl`(`paramsIdent`)))
+      proc `rpcProcWrapper`(`paramsIdent`: JsonNode): Future[RpcResult] {.async, raises: [Defect, CatchableError, Exception].} =
+        return some(StringOfJson($(await `rpcProcImpl`(`paramsIdent`))))
   elif ReturnType == ident"StringOfJson":
     result.add quote do:
-      proc `rpcProcWrapper`(`paramsIdent`: JsonNode): Future[StringOfJson] {.async, gcsafe.} =
-        return await `rpcProcImpl`(`paramsIdent`)
+      proc `rpcProcWrapper`(`paramsIdent`: JsonNode): Future[RpcResult] {.async, raises: [Defect, CatchableError, Exception].} =
+        return some(await `rpcProcImpl`(`paramsIdent`))
   else:
     result.add quote do:
-      proc `rpcProcWrapper`(`paramsIdent`: JsonNode): Future[StringOfJson] {.async, gcsafe.} =
-        return StringOfJson($(%(await `rpcProcImpl`(`paramsIdent`))))
+      proc `rpcProcWrapper`(`paramsIdent`: JsonNode): Future[RpcResult] {.async, raises: [Defect, CatchableError, Exception].} =
+        return some(StringOfJson($(%(await `rpcProcImpl`(`paramsIdent`)))))
 
   result.add quote do:
     `server`.register(`path`, `rpcProcWrapper`)

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -44,9 +44,9 @@ proc getWebSocketClientConfig*(
   ClientConfig(kind: WebSocket, wsUri: uri, compression: compression, flags: flags)
 
 proc proxyCall(client: RpcClient, name: string): RpcProc =
-  return proc (params: JsonNode): Future[StringOfJson] {.async.} =
-          let res = await client.call(name, params)
-          return StringOfJson($res)
+  return proc (params: JsonNode): Future[RpcResult] {.async, gcsafe, raises: [Defect, CatchableError, Exception].} =
+           let res = await client.call(name, params)
+           return some(StringOfJson($res))
 
 proc getClient(proxy: RpcProxy): RpcClient =
   case proxy.kind
@@ -91,7 +91,7 @@ proc start*(proxy: RpcProxy) {.async.} =
 template rpc*(server: RpcProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 
-proc registerProxyMethod*(proxy: var RpcProxy, methodName: string) =
+proc registerProxyMethod*(proxy: var RpcProxy, methodName: string) {.gcsafe, raises: [Defect, CatchableError, Exception].} =
   try:
     proxy.rpcHttpServer.register(methodName, proxyCall(proxy.getClient(), methodName))
   except CatchableError as err:

--- a/json_rpc/rpcserver.nim
+++ b/json_rpc/rpcserver.nim
@@ -1,3 +1,3 @@
-import server
+import server, chronos
 import servers/[socketserver, httpserver, websocketserver]
-export server, socketserver, httpserver, websocketserver
+export server, socketserver, httpserver, websocketserver, chronos

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -1,10 +1,10 @@
 import
   std/tables,
-  chronos,
+  faststreams/async_backend,
   ./router,
   ./jsonmarshal
 
-export chronos, jsonmarshal, router
+export jsonmarshal, router
 
 type
   RpcServer* = ref object of RootRef
@@ -23,12 +23,12 @@ template hasMethod*(server: RpcServer, methodName: string): bool =
 
 proc executeMethod*(server: RpcServer,
                     methodName: string,
-                    args: JsonNode): Future[StringOfJson] =
-  server.router.procs[methodName](args)
+                    args: JsonNode): Future[StringOfJson] {.async} =
+  return (await server.router.procs[methodName](args)).get
 
 # Wrapper for message processing
 
-proc route*(server: RpcServer, line: string): Future[string] {.gcsafe.} =
+proc route*(server: RpcServer, line: string): Future[RpcResult] {.gcsafe.} =
   server.router.route(line)
 
 # Server registration

--- a/json_rpc/servers/httpserver.nim
+++ b/json_rpc/servers/httpserver.nim
@@ -1,6 +1,5 @@
 import
   stew/byteutils,
-  std/[strutils],
   chronicles, httputils, chronos,
   chronos/apps/http/[httpserver, shttpserver],
   ".."/[errors, server]
@@ -30,9 +29,14 @@ proc processClientRpc(rpcServer: RpcServer): HttpProcessCallback =
         return await request.respond(Http503, "Internal error while processing JSON-RPC call")
       else:
         var data = future.read()
-        let res = await request.respond(Http200, data)
-        trace "JSON-RPC result has been sent"
-        return res
+        if data.isSome:
+          let res = await request.respond(Http200, string(data.get))
+          trace "JSON-RPC result has been sent"
+          return res
+        else:
+          let res = await request.respond(Http204)
+          trace "No-content has been sent"
+          return res
     else:
       return dumbResponse()
 

--- a/json_rpc/servers/socketserver.nim
+++ b/json_rpc/servers/socketserver.nim
@@ -1,7 +1,8 @@
 import
   chronicles,
   json_serialization/std/net,
-  ".."/[errors, server]
+  ".."/[errors, server],
+  chronos
 
 export errors, server
 
@@ -28,7 +29,8 @@ proc processClient(server: StreamServer, transport: StreamTransport) {.async, gc
     debug "Processing message", address = transport.remoteAddress(), line = value
 
     let res = await rpc.route(value)
-    discard await transport.write(res)
+    if res.isSome:
+      discard await transport.write(string(res.get))
 
 # Utility functions for setting up servers using stream transport addresses
 

--- a/json_rpc/servers/websocketserver.nim
+++ b/json_rpc/servers/websocketserver.nim
@@ -1,8 +1,8 @@
 import
-  chronicles, httputils, chronos, websock/websock,
+  chronicles, chronos, websock/websock,
   websock/extensions/compression/deflate,
   stew/byteutils, json_serialization/std/net,
-  ".."/[errors, server]
+  ".."/server
 
 export server, net
 
@@ -53,7 +53,8 @@ proc handleRequest(rpc: RpcWebSocketServer, request: HttpRequest) {.async.} =
       var data = future.read()
       trace "RPC result has been sent", address = $request.uri
 
-      await ws.send(data)
+      if data.isSome:
+        await ws.send(string(data.get))
 
   except WebSocketError as exc:
     error "WebSocket error:", exception = exc.msg

--- a/json_rpc/streamconnection.nim
+++ b/json_rpc/streamconnection.nim
@@ -1,0 +1,148 @@
+import
+  strutils,
+  streams,
+  faststreams/async_backend,
+  asynctools/asyncpipe,
+  faststreams/inputs,
+  faststreams/textio,
+  parseutils,
+  faststreams/asynctools_adapters,
+  ./json_rpc/[server, client]
+
+export jsonmarshal, router, server
+
+type
+  StreamClient* = ref object of RpcClient
+    output*: AsyncOutputStream
+  StreamConnection* = ref object of RpcServer
+    output*: AsyncOutputStream
+    client*: StreamClient
+  Handler[T, U] = proc(input: T): Future[U] {.gcsafe, raises: [Defect, CatchableError, Exception].}
+  HandlerWithId[T, U] = proc(input: T, id: int): Future[U] {.gcsafe, raises: [Defect, CatchableError, Exception].}
+  NotificationHandler[T] = proc(input: T): Future[void] {.gcsafe, raises: [Defect, CatchableError, Exception].}
+
+proc extractId  (id: JsonNode): int =
+  if id.kind == JInt:
+    result = id.getInt
+  if id.kind == JString:
+    discard parseInt(id.getStr, result)
+
+proc wrapJsonRpcResponse(s: string): string =
+  result = s & "\r\n"
+  result = "Content-Length: " & $s.len & "\r\n\r\n" & s
+
+proc wrap[T, Q](callback: Handler[T, Q]): RpcProc =
+  return
+    proc(input: JsonNode): Future[RpcResult] {.async} =
+      let res = await callback(to(input{"params"}, T))
+      return some(StringOfJson($(%res)))
+
+proc wrap[T, Q](callback: HandlerWithId[T, Q]): RpcProc =
+  return
+    proc(input: JsonNode): Future[RpcResult] {.async} =
+      let id = input{"id"}.extractId
+      let params = input{"params"}
+      return some(StringOfJson($(%(await callback(to(params, T), id)))))
+
+proc wrap[T](callback: NotificationHandler[T]): RpcProc =
+  return
+    proc(input: JsonNode): Future[RpcResult] {.async} =
+      await callback(to(input{"params"}, T))
+      return none[StringOfJson]()
+
+proc register*[T, Q](server: RpcServer, name: string, rpc: Handler[T, Q]) =
+  server.register(name, wrap(rpc))
+
+proc register*[T, Q](server: RpcServer, name: string, rpc: HandlerWithId[T, Q]) =
+  server.register(name, wrap(rpc))
+
+proc registerNotification*[T](server: RpcServer, name: string, rpc: NotificationHandler[T]) =
+  server.register(name, wrap(rpc))
+
+method call*(self: StreamClient,
+             name: string,
+             params: JsonNode): Future[Response] {.async} =
+  ## Remotely calls the specified RPC method.
+  let
+    id = self.getNextId()
+    value = wrapJsonRpcResponse($rpcCallNode(name, params, id))
+    # completed by processMessage.
+    newFut = newFuture[Response]()
+
+  # add to awaiting responses
+  self.awaiting[id] = newFut
+
+  write(OutputStream(self.output), value)
+  flush(self.output)
+  return await newFut
+
+proc call*(connection: StreamConnection, name: string,
+          params: JsonNode): Future[Response] {.gcsafe, raises: [Exception].} =
+  return connection.client.call(name, params)
+
+proc notify*(connection: StreamConnection, name: string,
+             params: JsonNode): Future[void] {.async.} =
+  let value = wrapJsonRpcResponse($rpcNotificationNode(name, params))
+  write(OutputStream(connection.output), value)
+  flush(connection.output)
+
+proc readMessage*(input: AsyncInputStream): Future[Option[string]] {.async.} =
+  var
+    contentLen = -1
+    headerStarted = false
+
+  while input.readable:
+    let ln = await input.readLine()
+    if ln.len != 0:
+      let sep = ln.find(':')
+      if sep == -1:
+        continue
+      let valueStart = skipWhitespace(ln, sep + 1) + sep + 1
+      case ln[0 ..< sep]
+      of "Content-Type":
+        if ln.find("utf-8", valueStart) == -1 and ln.find("utf8", valueStart) == -1:
+          raise newException(Exception, "only utf-8 is supported")
+      of "Content-Length":
+        if parseInt(ln, contentLen, valueStart) == 0:
+          raise newException(Exception, "invalid Content-Length: " &
+            ln.substr(valueStart))
+      else:
+        continue
+      headerStarted = true
+    elif not headerStarted:
+      continue
+    else:
+      if contentLen != -1:
+        if input.readable(contentLen):
+           return some(cast[string](`@`(input.read(contentLen))))
+        else:
+           return none[string]();
+  return none[string]();
+
+proc start*[T](conn: StreamConnection, input: T): Future[void] {.async} =
+  try:
+    var message = await readMessage(input);
+    while message.isSome:
+      let json = parseJson(message.get);
+      if (json{"result"}.isNil and json{"error"}.isNil):
+        proc cb(fut: Future[RpcResult]) {.gcsafe.} =
+          let res = fut.read
+          if res.isSome:
+            let resultMessage = wrapJsonRpcResponse(string(res.get));
+            write(OutputStream(conn.output), resultMessage);
+            flush(OutputStream(conn.output))
+        route(conn, message.get).addCallback(cb);
+      else:
+        conn.client.processMessage(message.get)
+      message = await readMessage(input);
+  except IOError:
+    return
+
+proc new*(T: type StreamConnection, output: AsyncPipe, fullParams = true): T =
+  let asyncOutput =  asyncPipeOutput(pipe = output, allowWaitFor = true);
+  result = T(output: asyncOutput, client: StreamClient(output: asyncOutput))
+  result.router.fullParams = fullParams
+
+proc new*(T: type StreamConnection, output: AsyncOutputStream, fullParams = true): T =
+  result.router.fullParams = fullParams
+  return T(output: output, client: StreamClient(output: output))

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,0 +1,3 @@
+# config to make nimsuggest happy.
+--define:"async_backend=asyncdispatch"
+--threads:on

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -3,8 +3,12 @@
 import
   ../json_rpc/clients/config
 
-import
-  testrpcmacro, testethcalls, testhttp, testserverclient
+import testhttp, testserverclient, testrpcmacro, testethcalls
+
+when not useNews:
+  # TODO The websock server doesn't interop properly
+  #      with the news client at the moment
+  import testserverclient
 
 when not useNews:
   # The proxy implementation is based on websock

--- a/tests/ethprocs.nim
+++ b/tests/ethprocs.nim
@@ -1,6 +1,7 @@
 import
   json,
   nimcrypto, stint,
+  chronos,
   ethtypes, ethhexstrings, stintjson, ../json_rpc/rpcserver
 
 #[
@@ -450,4 +451,3 @@ proc addEthRpcs*(server: RpcServer) =
     ## id: the filter id.
     ## Returns a list of messages received since last poll.
     discard
-

--- a/tests/testethcalls.nim
+++ b/tests/testethcalls.nim
@@ -1,7 +1,7 @@
 import
   unittest, json, tables,
   stint, ethtypes, ethprocs, stintjson, chronicles,
-  ../json_rpc/[rpcclient, rpcserver], ./helpers
+  ../json_rpc/[rpcclient, rpcserver], ./helpers, chronos
 
 from os import getCurrentDir, DirSep
 from strutils import rsplit

--- a/tests/testhttp.nim
+++ b/tests/testhttp.nim
@@ -1,5 +1,5 @@
-import unittest, json, strutils
-import httputils
+import unittest, json
+import chronos
 import ../json_rpc/[rpcserver, rpcclient]
 
 const TestsCount = 100

--- a/tests/testproxy.nim
+++ b/tests/testproxy.nim
@@ -1,11 +1,12 @@
 import
   unittest, json, chronicles,
-  ../json_rpc/[rpcclient, rpcserver, rpcproxy]
+  ../json_rpc/[rpcclient, rpcserver, rpcproxy],
+  faststreams/async_backend
 
 let srvAddress = initTAddress("127.0.0.1",  Port(8545))
 let proxySrvAddress = "localhost:8546"
 let proxySrvAddressForClient = "http://"&proxySrvAddress
-  
+
 template registerMethods(srv: RpcServer, proxy: RpcProxy) =
   srv.rpc("myProc") do(input: string, data: array[0..3, int]):
     return %("Hello " & input & " data: " & $data)
@@ -39,7 +40,7 @@ suite "Proxy RPC through http":
   test "Method missing on server and proxy server":
     expect(CatchableError):
       discard waitFor client.call("missingMethod", %[%"abc"])
-  
+
   waitFor srv.stop()
   waitFor srv.closeWait()
   waitFor proxy.stop()
@@ -68,7 +69,7 @@ suite "Proxy RPC through websockets":
   test "Method missing on server and proxy server":
     expect(CatchableError):
       discard waitFor client.call("missingMethod", %[%"abc"])
-  
+
   srv.stop()
   waitFor srv.closeWait()
   waitFor proxy.stop()

--- a/tests/testrpcmacro.nim
+++ b/tests/testrpcmacro.nim
@@ -1,5 +1,6 @@
 import unittest, json, chronicles, options
 import ../json_rpc/rpcserver, ./helpers
+import chronos
 
 type
   # some nested types to check object parsing

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -1,6 +1,6 @@
 import
-  unittest, json, chronicles,
-  ../json_rpc/[rpcclient, rpcserver, clients/config]
+  unittest, json, ../json_rpc/[rpcclient, rpcserver, clients/config],
+  faststreams/async_backend
 
 const
   compressionSupported = useNews

--- a/tests/teststreamconnection.nim
+++ b/tests/teststreamconnection.nim
@@ -1,0 +1,90 @@
+import
+  std/json,
+  unittest,
+  faststreams/async_backend,
+  faststreams/asynctools_adapters,
+  ../json_rpc/streamconnection
+
+type
+  DemoObject* = object
+    foo*: int
+    bar*: int
+
+# for testing purposes
+var
+  cachedInput: string
+  cachedDemoObject = newFuture[DemoObject]()
+  futureId = newFuture[int]()
+
+proc echo(params: string): Future[string] {.async,
+    raises: [CatchableError, Exception].} =
+  {.gcsafe.}:
+    cachedInput = params;
+  return params
+
+proc notifyDemoObject(params: DemoObject): Future[void] {.async} =
+  {.gcsafe.}:
+    cachedDemoObject.complete(params);
+  return
+
+suite "Client/server over JSONRPC":
+  let pipeServer = createPipe();
+  let pipeClient = createPipe();
+
+  proc echoDemoObject(params: DemoObject): Future[DemoObject] {.async,
+      raises: [CatchableError, Exception].} =
+    return params
+
+  proc echoDemoObjectWithId(params: DemoObject, id: int): Future[DemoObject] {.async,
+      raises: [CatchableError, Exception].} =
+    {.gcsafe.}:
+      futureId.complete(id)
+    return params
+
+  proc echoDemoObjectRaiseError(params: DemoObject): Future[DemoObject] {.async,
+      raises: [CatchableError, Exception].} =
+    raise newException(ValueError, "ValueError")
+
+  let serverConnection = StreamConnection.new(pipeServer);
+  serverConnection.register("echo", echo)
+  serverConnection.register("echoDemoObject", echoDemoObject)
+  serverConnection.register("echoDemoObjectWithId", echoDemoObjectWithId)
+  serverConnection.register("echoDemoObjectRaise", echoDemoObjectRaiseError)
+  serverConnection.registerNotification("demoObjectNotification", notifyDemoObject)
+
+  discard serverConnection.start(asyncPipeInput(pipeClient));
+
+  let clientConnection = StreamConnection.new(pipeClient);
+  discard clientConnection.start(asyncPipeInput(pipeServer));
+
+  test "Simple call.":
+    let response = clientConnection.call("echo", %"input").waitFor()
+    doAssert (response.getStr == "input")
+    doAssert (cachedInput == "input")
+
+  test "Call with object.":
+    let input =  DemoObject(foo: 1);
+    let response = clientConnection.call("echoDemoObject", %input).waitFor()
+    assert(to(response, DemoObject) == input)
+
+  test "Sending notification.":
+    let input =  DemoObject(foo: 2);
+    clientConnection.notify("demoObjectNotification", %input).waitFor()
+    assert(cachedDemoObject.waitFor == input)
+
+  test "Call with object/exception":
+    let input =  DemoObject(foo: 1);
+    try:
+      discard clientConnection.call("echoDemoObjectRaise", %input).waitFor()
+      doAssert false
+    except ValueError as e:
+      discard # expected
+
+  test "Call with object.":
+    let input =  DemoObject(foo: 1);
+    let response = clientConnection.call("echoDemoObjectWithId", %input).waitFor()
+    assert(to(response, DemoObject) == input)
+    assert(futureId.read == 4)
+
+  pipeClient.close()
+  pipeServer.close()


### PR DESCRIPTION
- implemented `streamconnection.nim` which aims to provide symetric
communication between two parties. In addition to the two-way communication I
have intruduced notifications (via StreamConnection.notify).

- Added faststreams to allow using asyncdispatch/chronos. This may cause
breakages in the `nim-json-rpc` clients which will at least need to specify
`asyncBackend=chronos` (and eventually add import `chronos` because I have removed
the export from `router.nim`/`server.nim`)

- Documentation is not part of the PR and will be added before the PR is merged.

- changed router.nim to allow passing the full jsonrpc request(not only the
`params`) to allow implementing `cancel` requests by having a way to pass the `id`
to the handler.

- Fixed several import not used and deprecated warnings