### PR TITLE
fix missing req id in router exception handler

### DIFF
--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -81,7 +81,7 @@ proc route*(router: RpcRouter, node: JsonNode): Future[StringOfJson] {.async, gc
       let res = await rpcProc(if params == nil: newJArray() else: params)
       return wrapReply(id, res)
     except InvalidRequest as err:
-      return wrapError(err.code, err.msg)
+      return wrapError(err.code, err.msg, id)
     except CatchableError as err:
       debug "Error occurred within RPC", methodName = methodName, err = err.msg
       return wrapError(

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -13,6 +13,9 @@ proc setupServer*(srv: RpcServer) =
   srv.rpc("myError") do(input: string, data: array[0..3, int]):
     raise (ref ValueError)(msg: "someMessage")
 
+  srv.rpc("invalidRequest") do():
+    raise (ref InvalidRequest)(code: -32001, msg: "Unknown payload")
+
 suite "Socket Server/Client RPC":
   var srv = newRpcSocketServer(["localhost:8545"])
   var client = newRpcSocketClient()
@@ -32,6 +35,13 @@ suite "Socket Server/Client RPC":
   test "Error RPC call":
     expect(CatchableError): # The error type wont be translated
       discard waitFor client.call("myError", %[%"abc", %[1, 2, 3, 4]])
+
+  test "Invalid request exception":
+    try:
+      discard waitFor client.call("invalidRequest", %[])
+      check false
+    except CatchableError as e:
+      check e.msg == """{"code":-32001,"message":"Unknown payload","data":null}"""
 
   srv.stop()
   waitFor srv.closeWait()
@@ -55,6 +65,13 @@ suite "Websocket Server/Client RPC":
   test "Error RPC call":
     expect(CatchableError): # The error type wont be translated
       discard waitFor client.call("myError", %[%"abc", %[1, 2, 3, 4]])
+
+  test "Invalid request exception":
+    try:
+      discard waitFor client.call("invalidRequest", %[])
+      check false
+    except CatchableError as e:
+      check e.msg == """{"code":-32001,"message":"Unknown payload","data":null}"""
 
   srv.stop()
   waitFor srv.closeWait()
@@ -80,6 +97,13 @@ suite "Websocket Server/Client RPC with Compression":
   test "Error RPC call":
     expect(CatchableError): # The error type wont be translated
       discard waitFor client.call("myError", %[%"abc", %[1, 2, 3, 4]])
+
+  test "Invalid request exception":
+    try:
+      discard waitFor client.call("invalidRequest", %[])
+      check false
+    except CatchableError as e:
+      check e.msg == """{"code":-32001,"message":"Unknown payload","data":null}"""
 
   srv.stop()
   waitFor srv.closeWait()


### PR DESCRIPTION
when an rpc method in server throw `InvalidRequest` using custom error code,
the router need to mention the request id too.

otherwise the client will throw error with confusing message.