### PR TITLE
request header callback

### DIFF
--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -19,6 +19,8 @@ type
 
   Response* = JsonNode
 
+  GetJsonRpcRequestHeaders* = proc(): seq[(string, string)] {.gcsafe.}
+
 proc getNextId*(client: RpcClient): ClientId =
   client.lastId += 1
   client.lastId

--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -116,8 +116,9 @@ when useNews:
       # TODO: This is a hack, because the table might be case sensitive. Ideally strtabs module has
       # to be extended with case insensitive accessors.
       headers["Origin"] = "http://localhost"
-    for header in client.getHeaders():
-      headers[header[0]] = header[1]
+    if not isNil(client.getHeaders):
+      for header in client.getHeaders():
+        headers[header[0]] = header[1]
     client.transport = await newWebSocket(uri, headers)
     client.uri = uri
     client.loop = processData(client)

--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -18,6 +18,7 @@ when useNews:
       transport*: WebSocket
       uri*: string
       loop*: Future[void]
+      getHeaders*: GetJsonRpcRequestHeaders
 
 else:
   import std/[uri, strutils]
@@ -28,13 +29,16 @@ else:
       transport*: WSSession
       uri*: Uri
       loop*: Future[void]
+      getHeaders*: GetJsonRpcRequestHeaders
 
-proc new*(T: type RpcWebSocketClient): T =
-  T()
+proc new*(
+    T: type RpcWebSocketClient, getHeaders: GetJsonRpcRequestHeaders = nil): T =
+  T(getHeaders: getHeaders)
 
-proc newRpcWebSocketClient*: RpcWebSocketClient =
+proc newRpcWebSocketClient*(
+    getHeaders: GetJsonRpcRequestHeaders = nil): RpcWebSocketClient =
   ## Creates a new client instance.
-  RpcWebSocketClient.new()
+  RpcWebSocketClient.new(getHeaders)
 
 method call*(self: RpcWebSocketClient, name: string,
              params: JsonNode): Future[Response] {.
@@ -112,6 +116,8 @@ when useNews:
       # TODO: This is a hack, because the table might be case sensitive. Ideally strtabs module has
       # to be extended with case insensitive accessors.
       headers["Origin"] = "http://localhost"
+    for header in client.getHeaders():
+      headers[header[0]] = header[1]
     client.transport = await newWebSocket(uri, headers)
     client.uri = uri
     client.loop = processData(client)


### PR DESCRIPTION
This allows a callback function to be defined such that both for HTTP (headers every `call`) and WebSocket (headers every `connect`), it can track a changing variable, time, for JWT authentication purposes:
```
{"jsonrpc":"2.0","id":6,"result":{"parentHash":"0xbc53afb1a29a0da3d2988134f9931ddb8c954e71f0bc623304caef56e40bdafb","feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","stateRoot":"0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x2","gasLimit":"0x1c8debe","gasUsed":"0x0","timestamp":"0x18","extraData":"0x","baseFeePerGas":"0x7","blockHash":"0x3b5d8b7bcd0ad1f9d577e7d2adcee100543af6eaee1751f293eae86455d71120","transactions":[]}}
> 2022/03/04 21:41:39.965728  length=1503 from=0 to=1502
POST / HTTP/1.1\r
Accept: */*\r
Content-Length: 1202\r
Content-Type: application/json\r
Host: 127.0.0.1\r
Connection: keep-alive\r
User-Agent: nim-chronos/3.0.2 (amd64/linux)\r
Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NDY0MjY0OTl9.r3_t2MMcg5hismTldKTFbi9BVdMDimfS-UJgNOe8bUM\r
\r
{"jsonrpc":"2.0","method":"engine_newPayloadV1","params":[{"parentHash":"0xbc53afb1a29a0da3d2988134f9931ddb8c954e71f0bc623304caef56e40bdafb","feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","stateRoot":"0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x2","gasLimit":"0x1C8DEBE","gasUsed":"0x0","timestamp":"0x18","extraData":"0x","baseFeePerGas":"0x7","blockHash":"0x3b5d8b7bcd0ad1f9d577e7d2adcee100543af6eaee1751f293eae86455d71120","transactions":[]}],"id":7}< 2022/03/04 21:41:39.976140  length=272 from=0 to=271
HTTP/1.1 200 OK\r
Content-Type: application/json\r
Date: Fri, 04 Mar 2022 20:41:39 GMT\r
Content-Length: 163\r
\r
{"jsonrpc":"2.0","id":7,"result":{"status":"VALID","latestValidHash":"0x3b5d8b7bcd0ad1f9d577e7d2adcee100543af6eaee1751f293eae86455d71120","validationError":null}}
> 2022/03/04 21:41:39.988598  length=807 from=0 to=806
POST / HTTP/1.1\r
Accept: */*\r
Content-Length: 507\r
Content-Type: application/json\r
Host: 127.0.0.1\r
Connection: keep-alive\r
User-Agent: nim-chronos/3.0.2 (amd64/linux)\r
Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NDY0MjY0OTl9.r3_t2MMcg5hismTldKTFbi9BVdMDimfS-UJgNOe8bUM\r
\r
{"jsonrpc":"2.0","method":"engine_forkchoiceUpdatedV1","params":[{"headBlockHash":"0x3b5d8b7bcd0ad1f9d577e7d2adcee100543af6eaee1751f293eae86455d71120","safeBlockHash":"0x3b5d8b7bcd0ad1f9d577e7d2adcee100543af6eaee1751f293eae86455d71120","finalizedBlockHash":"0x3b5d8b7bcd0ad1f9d577e7d2adcee100543af6eaee1751f293eae86455d71120"},{"timestamp":"0x24","prevRandao":"0x0000000000000000000000000000000000000000000000000000000000000000","suggestedFeeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"}],"id":8}< 2022/03/04 21:41:39.991007  length=323 from=0 to=322
HTTP/1.1 200 OK\r
Content-Type: application/json\r
Date: Fri, 04 Mar 2022 20:41:39 GMT\r
Content-Length: 214\r
\r
{"jsonrpc":"2.0","id":8,"result":{"payloadStatus":{"status":"VALID","latestValidHash":"0x3b5d8b7bcd0ad1f9d577e7d2adcee100543af6eaee1751f293eae86455d71120","validationError":null},"payloadId":"0x09553c57454dc2f8"}}
```
This is required by https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.7/src/engine/authentication.md which, so far despite some consideration of TLS, looks like it'll last at least some weeks, with the next merge testnet looking like it'll require this to even participate.