### PR TITLE
align `nim-websock` support with `news`

### DIFF
--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -1,6 +1,5 @@
 import
-  std/[strtabs, tables],
-  pkg/[chronos, chronicles],
+  pkg/[chronos, chronos/apps/http/httptable, chronicles],
   stew/byteutils,
   ../client, ./config
 
@@ -103,42 +102,60 @@ proc processData(client: RpcWebSocketClient) {.async.} =
   if not client.onDisconnect.isNil:
     client.onDisconnect()
 
+proc addExtraHeaders(
+    headers: var HttpTable,
+    client: RpcWebSocketClient,
+    extraHeaders: HttpTable) =
+  # Apply client instance overrides
+  if client.getHeaders != nil:
+    for header in client.getHeaders():
+      headers.add(header[0], header[1])
+
+  # Apply call specific overrides
+  for header in extraHeaders.stringItems:
+    headers.add(header.key, header.value)
+
+  # Apply default origin
+  discard headers.hasKeyOrPut("Origin", "http://localhost")
+
 when useNews:
+  func toStringTable(headersTable: HttpTable): StringTableRef =
+    let res = newStringTable(modeCaseInsensitive)
+    for header in headersTable:
+      res[header.key] = header.value.join(",")
+    res
+
   proc connect*(
       client: RpcWebSocketClient,
       uri: string,
-      headers: StringTableRef = nil,
+      extraHeaders: HttpTable = default(HttpTable),
       compression = false) {.async.} =
     if compression:
       warn "compression is not supported with the news back-end"
-    var headers = headers
-    if headers.isNil:
-      headers = newStringTable({"Origin": "http://localhost"})
-    elif "Origin" notin headers:
-      # TODO: This is a hack, because the table might be case sensitive. Ideally strtabs module has
-      # to be extended with case insensitive accessors.
-      headers["Origin"] = "http://localhost"
-    if not isNil(client.getHeaders):
-      for header in client.getHeaders():
-        headers[header[0]] = header[1]
-    client.transport = await newWebSocket(uri, headers)
+    var headers = HttpTable.init()
+    headers.addExtraHeaders(client, extraHeaders)
+    client.transport = await newWebSocket(uri, headers.toStringTable())
     client.uri = uri
     client.loop = processData(client)
 else:
   proc connect*(
-      client: RpcWebSocketClient, uri: string,
+      client: RpcWebSocketClient,
+      uri: string,
+      extraHeaders: HttpTable = default(HttpTable),
       compression = false,
       hooks: seq[Hook] = @[],
       flags: set[TLSFlags] = {NoVerifyHost, NoVerifyServerName}) {.async.} =
+    proc headersHook(ctx: Hook, headers: var HttpTable): Result[void, string] =
+      headers.addExtraHeaders(client, extraHeaders)
+      ok()
     var ext: seq[ExtFactory] = if compression: @[deflateFactory()]
                                else: @[]
     let uri = parseUri(uri)
     let ws = await WebSocket.connect(
       uri=uri,
       factories=ext,
-      hooks=hooks,
-      flags=flags
-    )
+      hooks=hooks & Hook(append: headersHook),
+      flags=flags)
     client.transport = ws
     client.uri = uri
     client.loop = processData(client)


### PR DESCRIPTION
To allow switching between `news` and `nim-websock` in `nimbus-eth2`,
add support for the missing CORS and JWT authorization headers to the
`nim-websock` backend. Also transition from `StringTableRef` to
`HttpTable` to properly support multiple instances of same header name.