### PR TITLE
do not disable TLS verification by default

### DIFF
--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -144,7 +144,7 @@ else:
       extraHeaders: HttpTable = default(HttpTable),
       compression = false,
       hooks: seq[Hook] = @[],
-      flags: set[TLSFlags] = {NoVerifyHost, NoVerifyServerName}) {.async.} =
+      flags: set[TLSFlags] = {}) {.async.} =
     proc headersHook(ctx: Hook, headers: var HttpTable): Result[void, string] =
       headers.addExtraHeaders(client, extraHeaders)
       ok()


### PR DESCRIPTION
Setting `NoVerifyHost`, `NoVerifyServerName` by default leads to hard-to-debug bugs, it should always be explicit if wanted.
Note: This is also a workaround for https://github.com/status-im/nim-chronos/issues/313