### PR TITLE
fix enum parsing, work around potential `nil` dereference

### DIFF
--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -160,7 +160,10 @@ proc createRpcFromSig*(clientType, rpcDecl: NimNode): NimNode =
   else:
     # native json expected so no work
     callBody.add quote do:
-      `procRes` = `rpcResult`
+      `procRes` = if `rpcResult` == nil:
+        newJNull()
+      else:
+        `rpcResult`
 
   when defined(nimDumpRpcs):
     echo pathStr, ":\n", result.repr

--- a/json_rpc/jsonmarshal.nim
+++ b/json_rpc/jsonmarshal.nim
@@ -35,11 +35,9 @@ proc fromJson*[T: enum](n: JsonNode, argName: string, result: var T) =
   n.kind.expect(JInt, argName)
 
   let v = n.getBiggestInt()
-  if v notin T:
+  if not checkedEnumAssign(result, v):
     raise (ref ValueError)(
       msg: "Unknown enum ordinal for " & name(T) & ": " & $v)
-
-  result = T(v)
 
 # This can't be forward declared: https://github.com/nim-lang/Nim/issues/7868
 proc fromJson*[T: object|tuple](n: JsonNode, argName: string, result: var T) =

--- a/json_rpc/jsonmarshal.nim
+++ b/json_rpc/jsonmarshal.nim
@@ -1,6 +1,6 @@
 import
   std/[macros, json, options, typetraits],
-  stew/byteutils
+  stew/[byteutils, objects]
 
 export json, options
 
@@ -33,7 +33,13 @@ proc fromJson*[T](n: JsonNode, argName: string, result: var Option[T])
 # This can't be forward declared: https://github.com/nim-lang/Nim/issues/7868
 proc fromJson*[T: enum](n: JsonNode, argName: string, result: var T) =
   n.kind.expect(JInt, argName)
-  result = n.getBiggestInt().T
+
+  let v = n.getBiggestInt()
+  if v notin T:
+    raise (ref ValueError)(
+      msg: "Unknown enum ordinal for " & name(T) & ": " & $v)
+
+  result = T(v)
 
 # This can't be forward declared: https://github.com/nim-lang/Nim/issues/7868
 proc fromJson*[T: object|tuple](n: JsonNode, argName: string, result: var T) =
@@ -145,6 +151,8 @@ proc fromJson*[N, T](n: JsonNode, argName: string, result: var array[N, T]) =
 
 proc unpackArg[T](args: JsonNode, argName: string, argtype: typedesc[T]): T =
   mixin fromJson
+  if args == nil:
+    raise (ref ValueError)(msg: argName & ": unexpected null value")
   fromJson(args, argName, result)
 
 proc expectArrayLen(node, jsonIdent: NimNode, length: int) =

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -174,4 +174,4 @@ macro rpc*(server: RpcRouter, path: string, body: untyped): untyped =
     `server`.register(`path`, `rpcProcWrapper`)
 
   when defined(nimDumpRpcs):
-    echo "\n", pathStr, ": ", result.repr
+    echo "\n", path, ": ", result.repr

--- a/tests/testrpcmacro.nim
+++ b/tests/testrpcmacro.nim
@@ -22,6 +22,10 @@ type
   MyOptionalNotBuiltin = object
     val: Option[Test2]
 
+  MyEnum = enum
+    Enum0
+    Enum1
+
 let
   testObj = %*{
     "a": %1,
@@ -39,6 +43,9 @@ var s = newRpcSocketServer(["localhost:8545"])
 # RPC definitions
 s.rpc("rpc.simplePath"):
   return %1
+
+s.rpc("rpc.enumParam") do(e: MyEnum):
+  return %[$e]
 
 s.rpc("rpc.differentParams") do(a: int, b: string):
   return %[%a, %b]
@@ -145,6 +152,14 @@ suite "Server types":
   test "Simple paths":
     let r = waitFor s.executeMethod("rpc.simplePath", %[])
     check r == "1"
+
+  test "Enum param paths":
+    block:
+      let r = waitFor s.executeMethod("rpc.enumParam", %[(int64(Enum1))])
+      check r == "[\"Enum1\"]"
+
+    expect(ValueError):
+      discard waitFor s.executeMethod("rpc.enumParam", %[(int64(42))])
 
   test "Different param types":
     let


### PR DESCRIPTION
When the bizarre error handling in the http client fails, it may happen that a nil is returned (maybe due to Nim bugs) - do it manually for now

alternative to #149 with an extra fix