### PR TITLE
Use JsonRpcError instead of ValueError

### DIFF
--- a/json_rpc/clients/socketclient.nim
+++ b/json_rpc/clients/socketclient.nim
@@ -1,7 +1,8 @@
 import
   std/tables,
   chronos,
-  ../client
+  ../client,
+  ../errors
 
 {.push raises: [Defect].}
 
@@ -28,7 +29,7 @@ method call*(self: RpcSocketClient, name: string,
   let id = self.getNextId()
   var value = $rpcCallNode(name, params, id) & "\r\n"
   if self.transport.isNil:
-    raise newException(ValueError,
+    raise newException(JsonRpcError,
                     "Transport is not initialised (missing a call to connect?)")
 
   # completed by processMessage.

--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -1,7 +1,7 @@
 import
   pkg/[chronos, chronos/apps/http/httptable, chronicles],
   stew/byteutils,
-  ../client, ./config
+  ../client, ../errors, ./config
 
 export client
 
@@ -48,7 +48,7 @@ method call*(self: RpcWebSocketClient, name: string,
   let id = self.getNextId()
   var value = $rpcCallNode(name, params, id) & "\r\n"
   if self.transport.isNil:
-    raise newException(ValueError,
+    raise newException(JsonRpcError,
                     "Transport is not initialised (missing a call to connect?)")
 
   # completed by processMessage.

--- a/tests/testhttp.nim
+++ b/tests/testhttp.nim
@@ -28,12 +28,12 @@ proc invalidTest(address: string, port: Port): Future[bool] {.async.} =
   try:
     var r = await client.call("invalidProcA", %[])
     discard r
-  except ValueError:
+  except JsonRpcError:
     invalidA = true
   try:
     var r = await client.call("invalidProcB", %[1, 2, 3])
     discard r
-  except ValueError:
+  except JsonRpcError:
     invalidB = true
   if invalidA and invalidB:
     result = true

--- a/tests/testhttps.nim
+++ b/tests/testhttps.nim
@@ -89,12 +89,12 @@ proc invalidTest(address: string, port: Port): Future[bool] {.async.} =
   try:
     var r = await client.call("invalidProcA", %[])
     discard r
-  except ValueError:
+  except JsonRpcError:
     invalidA = true
   try:
     var r = await client.call("invalidProcB", %[1, 2, 3])
     discard r
-  except ValueError:
+  except JsonRpcError:
     invalidB = true
   if invalidA and invalidB:
     result = true


### PR DESCRIPTION
Allows implementors of this library to distinguish between errors originating from this library.

Likely a breaking change for current users.