### PR TITLE
httpserver.nim: adding 'Content-Type: application/json' header to the response

### DIFF
--- a/json_rpc/servers/httpserver.nim
+++ b/json_rpc/servers/httpserver.nim
@@ -41,14 +41,19 @@ proc processClientRpc(rpcServer: RpcHttpServer): HttpProcessCallback =
 
       let body = await request.getBody()
 
+      var headers = HttpTable.init()
+      headers.add("Content-Type", "application/json; charset=utf-8")
+
       let future = rpcServer.route(string.fromBytes(body))
       yield future
       if future.failed:
         debug "Internal error while processing JSON-RPC call"
-        return await request.respond(Http503, "Internal error while processing JSON-RPC call")
+        return await request.respond(Http503,
+                              "Internal error while processing JSON-RPC call",
+                              headers)
       else:
         var data = future.read()
-        let res = await request.respond(Http200, data)
+        let res = await request.respond(Http200, data, headers)
         trace "JSON-RPC result has been sent"
         return res
     else:

--- a/json_rpc/servers/httpserver.nim
+++ b/json_rpc/servers/httpserver.nim
@@ -41,8 +41,8 @@ proc processClientRpc(rpcServer: RpcHttpServer): HttpProcessCallback =
 
       let body = await request.getBody()
 
-      var headers = HttpTable.init()
-      headers.add("Content-Type", "application/json; charset=utf-8")
+      let headers = HttpTable.init([("Content-Type",
+                                    "application/json; charset=utf-8")])
 
       let future = rpcServer.route(string.fromBytes(body))
       yield future


### PR DESCRIPTION
# Summary
This PR aims for applying the header "Content-Type: application/json; charset=utf-8" to all the json-rpc responses.

# Issue
https://github.com/waku-org/nwaku/issues/1783