### PR TITLE
use JsonNode.isNil rather than == nil to work around Nim issues

### DIFF
--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -38,7 +38,7 @@ method close*(client: RpcClient): Future[void] {.
   discard
 
 template `or`(a: JsonNode, b: typed): JsonNode =
-  if a == nil: b else: a
+  if a.isNil: b else: a
 
 proc processMessage*(self: RpcClient, line: string) =
   # Note: this doesn't use any transport code so doesn't need to be
@@ -163,7 +163,7 @@ proc createRpcFromSig*(clientType, rpcDecl: NimNode): NimNode =
   else:
     # native json expected so no work
     callBody.add quote do:
-      `procRes` = if `rpcResult` == nil:
+      `procRes` = if `rpcResult`.isNil:
         newJNull()
       else:
         `rpcResult`

--- a/json_rpc/jsonmarshal.nim
+++ b/json_rpc/jsonmarshal.nim
@@ -148,7 +148,7 @@ proc fromJson*[N, T](n: JsonNode, argName: string, result: var array[N, T]) =
 
 proc unpackArg[T](args: JsonNode, argName: string, argtype: typedesc[T]): T =
   mixin fromJson
-  if args == nil:
+  if args.isNil:
     raise (ref ValueError)(msg: argName & ": unexpected null value")
   {.gcsafe.}:
     fromJson(args, argName, result)


### PR DESCRIPTION
https://github.com/nim-lang/Nim/issues/22253 and https://github.com/nim-lang/Nim/issues/22254 in particular

That said, in this case, because `JsonNode` defines [a fairly heavyweight `==` operator](https://github.com/nim-lang/Nim/blob/1cd48e4b2abd867adf1ab52a70a1d8f1c6ac77c4/lib/pure/json.nim#L442-L474), whereas this needs only to check a more specific condition, using `isNil` is probably better here regardless.