### PR TITLE
Add framework to support more optional types

### DIFF
--- a/json_rpc/private/server_handler_wrapper.nim
+++ b/json_rpc/private/server_handler_wrapper.nim
@@ -22,10 +22,10 @@ export
   jsonmarshal
 
 type
-  RpcSetup* = object
-    numFields*: int
-    numOptionals*: int
-    minLength*: int
+  RpcSetup = object
+    numFields: int
+    numOptionals: int
+    minLength: int
 
 {.push gcsafe, raises: [].}
 
@@ -116,7 +116,7 @@ template unpackPositional(params: RequestParamsRx,
                           paramVar: auto,
                           paramName: static[string],
                           pos: static[int],
-                          minLength: static[int],
+                          setup: static[RpcSetup],
                           paramType: type) =
   ## Convert a positional parameter from Json into Nim
 
@@ -125,7 +125,7 @@ template unpackPositional(params: RequestParamsRx,
 
   # e.g. (A: int, B: Option[int], C: string, D: Option[int], E: Option[string])
   when rpc_isOptional(paramVar):
-    when pos >= minLength:
+    when pos >= setup.minLength:
       # allow both empty and null after mandatory args
       # D & E fall into this category
       if params.len > pos and params.notNull(pos):
@@ -267,7 +267,7 @@ proc wrapServerHandler*(methName: string, params, procBody, procWrapper: NimNode
                        `paramsObj`.`paramIdent`,
                        `paramName`,
                        `pos`,
-                       `rpcSetup`.minLength,
+                       `rpcSetup`,
                        `paramType`)
 
     executeParams.add quote do:

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -137,7 +137,7 @@ proc route*(router: RpcRouter, req: RequestRx):
     let methodName = req.meth.get # this Opt already validated
     debug "Error occurred within RPC",
       methodName = methodName, err = err.msg
-    return serverError(methodName & " raised an exception",
+    return serverError("`" & methodName & "` raised an exception",
       escapeJson(err.msg).JsonString).
       wrapError(req.id)
 

--- a/tests/test_batch_call.nim
+++ b/tests/test_batch_call.nim
@@ -56,7 +56,7 @@ suite "Socket batch call":
     check r[1].result.string == "\"apple: green\""
 
     check r[2].error.isSome
-    check r[2].error.get == """{"code":-32000,"message":"get_except raised an exception","data":"get_except error"}"""
+    check r[2].error.get == """{"code":-32000,"message":"`get_except` raised an exception","data":"get_except error"}"""
     check r[2].result.string.len == 0
 
   test "rpc call after batch call":
@@ -95,7 +95,7 @@ suite "HTTP batch call":
     check r[1].result.string == "\"apple: green\""
 
     check r[2].error.isSome
-    check r[2].error.get == """{"code":-32000,"message":"get_except raised an exception","data":"get_except error"}"""
+    check r[2].error.get == """{"code":-32000,"message":"`get_except` raised an exception","data":"get_except error"}"""
     check r[2].result.string.len == 0
 
   test "rpc call after batch call":
@@ -134,7 +134,7 @@ suite "Websocket batch call":
     check r[1].result.string == "\"apple: green\""
 
     check r[2].error.isSome
-    check r[2].error.get == """{"code":-32000,"message":"get_except raised an exception","data":"get_except error"}"""
+    check r[2].error.get == """{"code":-32000,"message":"`get_except` raised an exception","data":"get_except error"}"""
     check r[2].result.string.len == 0
 
   test "rpc call after batch call":


### PR DESCRIPTION
This PR add a framework to rpc server by using more templates than macros to handle optional types. 
RPC server recognize both `std/options` and `results.Opt` as optional type for the parameters. 
If needed user can add more optional types by overloading `rpc_isOptional` template. e.g. add support for or ptr/ref object as optional.
Now aliases to optional types also works.

Optional object fields is handled by nim-json-rpc as usual. This PR is targeting optional parameters of RPC methods.

fix #202 