### PR TITLE
align maximum body size between Websock and HTTP transports

### DIFF
--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -28,6 +28,8 @@ export
   ResponseBatchRx,
   results
 
+const MaxMessageBodyBytes* = 128 * 1024 * 1024  # 128 MB (JSON encoded)
+
 type
   RpcBatchItem* = object
     meth*: string
@@ -266,4 +268,3 @@ macro createRpcSigsFromNim*(clientType: untyped, procList: untyped): untyped =
   processRpcSigs(clientType, procList)
 
 {.pop.}
-

--- a/json_rpc/clients/httpclient.nim
+++ b/json_rpc/clients/httpclient.nim
@@ -33,9 +33,6 @@ type
     maxBodySize: int
     getHeaders: GetJsonRpcRequestHeaders
 
-const
-  MaxHttpRequestSize = 128 * 1024 * 1024 # maximum size of HTTP body in octets
-
 {.push gcsafe, raises: [].}
 
 # ------------------------------------------------------------------------------
@@ -43,7 +40,7 @@ const
 # ------------------------------------------------------------------------------
 
 proc new(
-    T: type RpcHttpClient, maxBodySize = MaxHttpRequestSize, secure = false,
+    T: type RpcHttpClient, maxBodySize = MaxMessageBodyBytes, secure = false,
     getHeaders: GetJsonRpcRequestHeaders = nil, flags: HttpClientFlags = {}): T =
 
   var moreFlags: HttpClientFlags
@@ -132,7 +129,7 @@ proc callImpl(client: RpcHttpClient, reqBody: string): Future[string] {.async.} 
 # ------------------------------------------------------------------------------
 
 proc newRpcHttpClient*(
-    maxBodySize = MaxHttpRequestSize, secure = false,
+    maxBodySize = MaxMessageBodyBytes, secure = false,
     getHeaders: GetJsonRpcRequestHeaders = nil,
     flags: HttpClientFlags = {}): RpcHttpClient =
   RpcHttpClient.new(maxBodySize, secure, getHeaders, flags)

--- a/json_rpc/clients/websocketclientimpl.nim
+++ b/json_rpc/clients/websocketclientimpl.nim
@@ -77,7 +77,7 @@ proc processData(client: RpcWebSocketClient) {.async.} =
   let ws = client.transport
   try:
     while ws.readyState != ReadyState.Closed:
-      var value = await ws.recvMsg()
+      var value = await ws.recvMsg(MaxMessageBodyBytes)
 
       if value.len == 0:
         # transmission ends


### PR DESCRIPTION
HTTP has a 128 MB limit, while websock uses the library default (20 MB). Align both to 128 MB. This should be enough for an Ethereum `getPayload` with 6 blobs, all hex encoded binary + JSON overhead.