### PR TITLE
avoid failing uninitialized `Future`

### DIFF
--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -174,9 +174,7 @@ proc processMessage*(client: RpcClient, line: string): Result[void, string] =
     var requestFut: Future[JsonString]
     let id = response.id.get
     if not client.awaiting.pop(id, requestFut):
-      let msg = "Cannot find message id \"" & $id & "\":"
-      requestFut.fail(newException(JsonRpcError, msg))
-      return ok()
+      return err("Cannot find message id \"" & $id & "\"")
 
     if response.error.isSome:
       let error = JrpcSys.encode(response.error.get)
@@ -266,4 +264,3 @@ macro createRpcSigsFromNim*(clientType: untyped, procList: untyped): untyped =
   processRpcSigs(clientType, procList)
 
 {.pop.}
-


### PR DESCRIPTION
In #195, a regression got introduced where an uninitialized `requestFut` gets `fail()`-ed if the message's `id` cannot be found in pending list. Revert back to return an `err()` instead, as before.