### PR TITLE
Introduce custom application error with optional data object

### DIFF
--- a/json_rpc/errors.nim
+++ b/json_rpc/errors.nim
@@ -1,11 +1,15 @@
 # json-rpc
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+
+{.push raises: [].}
+
+import results, json_serialization
 
 type
   JsonRpcError* = object of CatchableError
@@ -28,8 +32,7 @@ type
   RpcAddressUnresolvableError* = object of JsonRpcError
 
   InvalidRequest* = object of JsonRpcError
-    ## This could be raised by request handlers when the server
-    ## needs to respond with a custom error code.
+    ## raised when the server recieves an invalid JSON request object
     code*: int
 
   RequestDecodeError* = object of JsonRpcError
@@ -38,3 +41,11 @@ type
   ParamsEncodeError* = object of JsonRpcError
     ## raised when fail to encode RequestParamsTx
 
+  ApplicationError* = object of JsonRpcError
+    ## Error to be raised by the application request handlers when the server
+    ## needs to respond with a custom application error. The error code should
+    ## be outside the range of -32768 to -32000. A custom JSON data object may
+    ## be provided.
+    code*: int
+    message*: string
+    data*: results.Opt[JsonString]


### PR DESCRIPTION
This addresses two items:
- Use ApplicationError instead of InvalidRequest for custom application errors. Avoiding confusing regarding the usage of InvalidRequest (although the actual error code used could/would be different).
- Allow for defining an optional data object that gets returned in the error response, as per json-rpc specification.