### PR TITLE
chore: changing log level to trace for sending message print

### DIFF
--- a/json_rpc/clients/httpclient.nim
+++ b/json_rpc/clients/httpclient.nim
@@ -142,7 +142,7 @@ method call*(client: RpcHttpClient, name: string,
     id = client.getNextId()
     reqBody = requestTxEncode(name, params, id)
 
-  debug "Sending message to RPC server",
+  trace "Sending message to RPC server",
          address = client.httpAddress, msg_len = len(reqBody), name
   trace "Message", msg = reqBody
 


### PR DESCRIPTION
In applications with recurring RPC requests, this print can pollute the logs way too much. 

As a result, propose to have this log set to trace :)