### PR TITLE
Export errors for json-rpc clients

### DIFF
--- a/json_rpc/clients/httpclient.nim
+++ b/json_rpc/clients/httpclient.nim
@@ -18,7 +18,7 @@ import
   ../private/jrpc_sys
 
 export
-  client, HttpClientFlag, HttpClientFlags
+  client, errors, HttpClientFlag, HttpClientFlags
 
 logScope:
   topics = "JSONRPC-HTTP-CLIENT"

--- a/json_rpc/clients/socketclient.nim
+++ b/json_rpc/clients/socketclient.nim
@@ -16,7 +16,7 @@ import
   ../errors,
   ../private/jrpc_sys
 
-export client
+export client, errors
 
 logScope:
   topics = "JSONRPC-SOCKET-CLIENT"

--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -16,4 +16,5 @@ import
 
 export
   websocketclientimpl,
-  client
+  client,
+  errors


### PR DESCRIPTION
Errors should get exported considering they are part of the json-rpc APIs.