### PR TITLE
Some minimal changes to be able to base the `nimlangserver` in `json_rpc`

### DIFF
--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -114,3 +114,22 @@ suite "Websocket Server/Client RPC with Compression":
   srv.stop()
   waitFor srv.closeWait()
 
+suite "Custom processClient":
+  test "Should be able to use custom processClient":
+    var srv = newRpcSocketServer()
+    var wasCalled = false
+    
+    proc processClientHook(server: StreamServer, transport: StreamTransport) {.async: (raises: []), gcsafe.} =
+      wasCalled = true
+    
+    srv.processClientHook = processClientHook
+    
+    srv.addStreamServer("localhost", Port(8888))
+    var client = newRpcSocketClient()
+    srv.setupServer()
+    srv.start()
+    waitFor client.connect(srv.localAddress()[0])
+    asyncCheck client.call("", %[])
+    srv.stop()
+    waitFor srv.closeWait()
+    check wasCalled


### PR DESCRIPTION
- `processClientHook`: This is useful to shape the request and response to defined protocols (i.e. lsp)
- overloads `tryRoute`: So it doesnt parse the `json` inside. 

