### PR TITLE
Various error handling and processing fixes

### DIFF
--- a/json_rpc.nimble
+++ b/json_rpc.nimble
@@ -57,4 +57,4 @@ task test, "run tests":
 
   when not defined(windows):
     # on windows, socker server build failed
-    buildOnly "-d:\"chronicles_sinks=textlines[dynamic],json[dynamic]\"", "tests/all"
+    buildOnly "-d:chronicles_log_level=TRACE -d:\"chronicles_sinks=textlines[dynamic],json[dynamic]\"", "tests/all"

--- a/json_rpc/clients/httpclient.nim
+++ b/json_rpc/clients/httpclient.nim
@@ -182,7 +182,7 @@ method callBatch*(client: RpcHttpClient,
                     {.async.} =
   let reqBody = requestBatchEncode(calls)
   debug "Sending JSON-RPC batch",
-        address = client.httpAddress, len = len(reqBody)
+        address = $client.httpAddress, len = len(reqBody)
   let resText = await client.callImpl(reqBody)
 
   if client.batchFut.isNil or client.batchFut.finished():

--- a/json_rpc/clients/socketclient.nim
+++ b/json_rpc/clients/socketclient.nim
@@ -54,7 +54,7 @@ method call*(client: RpcSocketClient, name: string,
   client.awaiting[id] = newFut
 
   debug "Sending JSON-RPC request",
-         address = client.address, len = len(reqBody), name, id
+         address = $client.address, len = len(reqBody), name, id
 
   let res = await client.transport.write(reqBody)
   # TODO: Add actions when not full packet was send, e.g. disconnect peer.
@@ -74,7 +74,7 @@ method callBatch*(client: RpcSocketClient,
 
   let reqBody = requestBatchEncode(calls) & "\r\n"
   debug "Sending JSON-RPC batch",
-        address = client.address, len = len(reqBody)
+        address = $client.address, len = len(reqBody)
   let res = await client.transport.write(reqBody)
 
   # TODO: Add actions when not full packet was send, e.g. disconnect peer.

--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   ./websocketclientimpl,
   ../client

--- a/json_rpc/clients/websocketclientimpl.nim
+++ b/json_rpc/clients/websocketclientimpl.nim
@@ -10,7 +10,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/[uri, strutils],
+  std/uri,
   pkg/websock/[websock, extensions/compression/deflate],
   pkg/[chronos, chronos/apps/http/httptable, chronicles],
   stew/byteutils,
@@ -53,7 +53,7 @@ method call*(client: RpcWebSocketClient, name: string,
   client.awaiting[id] = newFut
 
   debug "Sending JSON-RPC request",
-         address = client.uri, len = len(reqBody), name
+         address = $client.uri, len = len(reqBody), name
 
   await client.transport.send(reqBody)
   return await newFut
@@ -70,7 +70,7 @@ method callBatch*(client: RpcWebSocketClient,
 
   let reqBody = requestBatchEncode(calls) & "\r\n"
   debug "Sending JSON-RPC batch",
-         address = client.uri, len = len(reqBody)
+         address = $client.uri, len = len(reqBody)
   await client.transport.send(reqBody)
 
   return await client.batchFut

--- a/json_rpc/errors.nim
+++ b/json_rpc/errors.nim
@@ -7,7 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import results, json_serialization
 

--- a/json_rpc/jsonmarshal.nim
+++ b/json_rpc/jsonmarshal.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   json_serialization
 
@@ -19,6 +21,6 @@ createJsonFlavor JrpcConv,
   omitOptionalFields = true, # Skip optional fields==none in Writer
   allowUnknownFields = true,
   skipNullFields = true      # Skip optional fields==null in Reader
-                           
+
 # JrpcConv is a namespace/flavor for encoding and decoding
 # parameters and return value of a rpc method.

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -7,28 +7,23 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   macros,
   ./shared_wrapper,
   ./jrpc_sys
-
-{.push gcsafe, raises: [].}
 
 proc createRpcProc(procName, parameters, callBody: NimNode): NimNode =
   # parameters come as a tree
   var paramList = newSeq[NimNode]()
   for p in parameters: paramList.add(p)
 
-  let body = quote do:
-    {.gcsafe.}:
-      `callBody`
-
   # build proc
-  result = newProc(procName, paramList, body)
+  result = newProc(procName, paramList, callBody)
 
   # make proc async
   result.addPragma ident"async"
-  result.addPragma ident"gcsafe"
   # export this proc
   result[0] = nnkPostfix.newTree(ident"*", newIdentNode($procName))
 

--- a/json_rpc/private/jrpc_sys.nim
+++ b/json_rpc/private/jrpc_sys.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   std/hashes,
   results,
@@ -153,8 +155,6 @@ RequestRx.useDefaultReaderIn JrpcSys
 
 const
   JsonRPC2Literal = JsonString("\"2.0\"")
-
-{.push gcsafe, raises: [].}
 
 func hash*(x: RequestId): hashes.Hash =
   var h = 0.Hash

--- a/json_rpc/private/server_handler_wrapper.nim
+++ b/json_rpc/private/server_handler_wrapper.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   std/[macros, typetraits],
   stew/[byteutils, objects],
@@ -26,8 +28,6 @@ type
     numFields: int
     numOptionals: int
     minLength: int
-
-{.push gcsafe, raises: [].}
 
 # ------------------------------------------------------------------------------
 # Optional resolvers
@@ -311,7 +311,7 @@ func wrapServerHandler*(methName: string, params, procBody, procWrapper: NimNode
   result = newStmtList()
   result.add handler
   result.add quote do:
-    proc `procWrapper`(`paramsIdent`: RequestParamsRx): Future[JsonString] {.async, gcsafe.} =
+    proc `procWrapper`(`paramsIdent`: RequestParamsRx): Future[JsonString] {.async.} =
       # Avoid 'yield in expr not lowered' with an intermediate variable.
       # See: https://github.com/nim-lang/Nim/issues/17849
       `setup`

--- a/json_rpc/private/shared_wrapper.nim
+++ b/json_rpc/private/shared_wrapper.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   std/[json, macros],
   ./jrpc_sys,

--- a/json_rpc/private/utils.nim
+++ b/json_rpc/private/utils.nim
@@ -1,0 +1,62 @@
+import chronos, ../errors
+
+from std/net import IPv6_any, IPv4_any
+
+template processResolvedAddresses(what: string) =
+  if ips.len == 0:
+    # Addresses could not be resolved, critical error.
+    raise newException(RpcAddressUnresolvableError, "Unable to resolve " & what)
+
+  var dualStack = Opt.none(Port)
+  for ip in ips:
+    # Only yield the "any" address once because we try to use dual stack where
+    # available
+    if ip.toIpAddress() == IPv6_any():
+      dualStack = Opt.some(ip.port)
+    elif ip.toIpAddress() == IPv4_any() and dualStack == Opt.some(ip.port):
+      continue
+    yield ip
+
+iterator resolveIP*(
+    addresses: openArray[string]
+): TransportAddress {.raises: [JsonRpcError].} =
+  var ips: seq[TransportAddress]
+  # Resolve IPv6 first so that dual stack detection works as expected
+  for address in addresses:
+    try:
+      for resolved in resolveTAddress(address, AddressFamily.IPv6):
+        if resolved notin ips:
+          ips.add resolved
+    except TransportAddressError:
+      discard
+
+  for address in addresses:
+    try:
+      for resolved in resolveTAddress(address, AddressFamily.IPv4):
+        if resolved notin ips:
+          ips.add resolved
+    except TransportAddressError:
+      discard
+
+  processResolvedAddresses($addresses)
+
+iterator resolveIP*(
+    address: string, port: Port
+): TransportAddress {.raises: [JsonRpcError].} =
+  var ips: seq[TransportAddress]
+  # Resolve IPv6 first so that dual stack detection works as expected
+  try:
+    for resolved in resolveTAddress(address, port, AddressFamily.IPv6):
+      if resolved notin ips:
+        ips.add resolved
+  except TransportAddressError:
+    discard
+
+  try:
+    for resolved in resolveTAddress(address, port, AddressFamily.IPv4):
+      if resolved notin ips:
+        ips.add resolved
+  except TransportAddressError:
+    discard
+
+  processResolvedAddresses($address & ":" & $port)

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -153,7 +153,7 @@ proc route*(router: RpcRouter, req: RequestRx):
       escapeJson(err.msg).JsonString).
       wrapError(req.id)
 
-proc route*(router: RpcRouter, data: string):
+proc route*(router: RpcRouter, data: string|seq[byte]):
        Future[string] {.async: (raises: []).} =
   ## Route to RPC from string data. Data is expected to be able to be
   ## converted to Json.

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   std/[macros, tables, json],
   chronicles,
@@ -24,7 +26,7 @@ export
 type
   # Procedure signature accepted as an RPC call by server
   RpcProc* = proc(params: RequestParamsRx): Future[JsonString]
-              {.gcsafe, raises: [CatchableError].}
+              {.async.}
 
   RpcRouter* = object
     procs*: Table[string, RpcProc]
@@ -39,8 +41,6 @@ const
   JSON_ENCODE_ERROR* = -32001
 
   defaultMaxRequestLength* = 1024 * 128
-
-{.push gcsafe, raises: [].}
 
 # ------------------------------------------------------------------------------
 # Private helpers
@@ -127,12 +127,15 @@ proc hasMethod*(router: RpcRouter, methodName: string): bool =
   router.procs.hasKey(methodName)
 
 proc route*(router: RpcRouter, req: RequestRx):
-             Future[ResponseTx] {.gcsafe, async: (raises: []).} =
+             Future[ResponseTx] {.async: (raises: []).} =
   let rpcProc = router.validateRequest(req).valueOr:
     return wrapError(error, req.id)
 
   try:
+    debug "Processing JSON-RPC request", id = req.id, name = req.`method`.get()
     let res = await rpcProc(req.params)
+    debug "Returning JSON-RPC response",
+      id = req.id, name = req.`method`.get(), len = string(res).len
     return wrapReply(res, req.id)
   except ApplicationError as err:
     return wrapError(applicationError(err.code, err.msg, err.data), req.id)
@@ -150,92 +153,34 @@ proc route*(router: RpcRouter, req: RequestRx):
       escapeJson(err.msg).JsonString).
       wrapError(req.id)
 
-proc wrapErrorAsync*(code: int, msg: string):
-       Future[JsonString] {.gcsafe, async: (raises: []).} =
-  return wrapError(code, msg).JsonString
-
 proc route*(router: RpcRouter, data: string):
-       Future[string] {.gcsafe, async: (raises: []).} =
+       Future[string] {.async: (raises: []).} =
   ## Route to RPC from string data. Data is expected to be able to be
   ## converted to Json.
   ## Returns string of Json from RPC result/error node
-  when defined(nimHasWarnBareExcept):
-    {.push warning[BareExcept]:off.}
-
   let request =
     try:
       JrpcSys.decode(data, RequestBatchRx)
     except CatchableError as err:
       return wrapError(JSON_PARSE_ERROR, err.msg)
-    except Exception as err:
-      # TODO https://github.com/status-im/nimbus-eth2/issues/2430
-      return wrapError(JSON_PARSE_ERROR, err.msg)
-
-  let reply = try:
-      if request.kind == rbkSingle:
-        let response = await router.route(request.single)
-        JrpcSys.encode(response)
-      elif request.many.len == 0:
-        wrapError(INVALID_REQUEST, "no request object in request array")
-      else:
-        var resFut: seq[Future[ResponseTx]]
-        for req in request.many:
-          resFut.add router.route(req)
-        await noCancel(allFutures(resFut))
-        var response = ResponseBatchTx(kind: rbkMany)
-        for fut in resFut:
-          response.many.add fut.read()
-        JrpcSys.encode(response)
-    except CatchableError as err:
-      wrapError(JSON_ENCODE_ERROR, err.msg)
-    except Exception as err:
-      wrapError(JSON_ENCODE_ERROR, err.msg)
-
-  when defined(nimHasWarnBareExcept):
-    {.pop warning[BareExcept]:on.}
-
-  return reply
-
-proc tryRoute*(router: RpcRouter, req: RequestRx,
-               fut: var Future[JsonString]): Result[void, string] =
-  ## Route to RPC, returns false if the method or params cannot be found.
-  ## Expects RequestRx input and returns json output.
-  when defined(nimHasWarnBareExcept):
-    {.push warning[BareExcept]:off.}
-    {.push warning[UnreachableCode]:off.}
 
   try:
-    if req.jsonrpc.isNone:
-      return err("`jsonrpc` missing or invalid")
-
-    if req.meth.isNone:
-      return err("`method` missing or invalid")
-
-    let rpc = router.procs.getOrDefault(req.meth.get)
-    if rpc.isNil:
-      return err("rpc method not found: " & req.meth.get)
-
-    fut = rpc(req.params)
-    return ok()
-
-  except CatchableError as ex:
-    return err(ex.msg)
-  except Exception as ex:
-    return err(ex.msg)
-
-  when defined(nimHasWarnBareExcept):
-    {.pop warning[BareExcept]:on.}
-    {.pop warning[UnreachableCode]:on.}
-
-proc tryRoute*(router: RpcRouter, data: JsonString,
-               fut: var Future[JsonString]): Result[void, string] =
-  ## Route to RPC, returns false if the method or params cannot be found.
-  ## Expects json input and returns json output.
-  try:
-    let req = JrpcSys.decode(data.string, RequestRx)
-    return router.tryRoute(req, fut)
-  except CatchableError as ex:
-    return err(ex.msg)
+    if request.kind == rbkSingle:
+      let response = await router.route(request.single)
+      JrpcSys.encode(response)
+    elif request.many.len == 0:
+      wrapError(INVALID_REQUEST, "no request object in request array")
+    else:
+      var resFut: seq[Future[ResponseTx]]
+      for req in request.many:
+        resFut.add router.route(req)
+      await noCancel(allFutures(resFut))
+      var response = ResponseBatchTx(kind: rbkMany)
+      for fut in resFut:
+        response.many.add fut.read()
+      JrpcSys.encode(response)
+  except CatchableError as err:
+    wrapError(JSON_ENCODE_ERROR, err.msg)
 
 macro rpc*(server: RpcRouter, path: static[string], body: untyped): untyped =
   ## Define a remote procedure call.

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
    pkg/websock/websock,
   ./servers/[httpserver],
@@ -39,8 +41,6 @@ type
       compression*: bool
       flags*: set[TLSFlags]
 
-{.push gcsafe, raises: [].}
-
 # TODO Add validations that provided uri-s are correct https/wss uri and retrun
 #  Result[string, ClientConfig]
 proc getHttpClientConfig*(uri: string): ClientConfig =
@@ -54,7 +54,7 @@ proc getWebSocketClientConfig*(
   ClientConfig(kind: WebSocket, wsUri: uri, compression: compression, flags: flags)
 
 proc proxyCall(client: RpcClient, name: string): RpcProc =
-  return proc (params: RequestParamsRx): Future[JsonString] {.gcsafe, async.} =
+  return proc (params: RequestParamsRx): Future[JsonString] {.async.} =
           let res = await client.call(name, params.toTx)
           return res
 
@@ -129,5 +129,5 @@ proc closeWait*(proxy: RpcProxy) {.async.} =
 
 func localAddress*(proxy: RpcProxy): seq[TransportAddress] =
   proxy.rpcHttpServer.localAddress()
-  
+
 {.pop.}

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -84,6 +84,8 @@ proc executeMethod*(server: RpcServer,
 
 proc route*(server: RpcServer, line: string): Future[string] {.async: (raises: [], raw: true).} =
   server.router.route(line)
+proc route*(server: RpcServer, line: seq[byte]): Future[string] {.async: (raises: [], raw: true).} =
+  server.router.route(line)
 
 # Server registration
 

--- a/json_rpc/servers/httpserver.nim
+++ b/json_rpc/servers/httpserver.nim
@@ -33,7 +33,8 @@ type
   # - nil: auth success, continue execution
   # - HttpResponse: could not authenticate, stop execution
   #   and return the response
-  HttpAuthHook* = proc(request: HttpRequestRef): Future[HttpResponseRef] {.async.}
+  HttpAuthHook* =
+    proc(request: HttpRequestRef): Future[HttpResponseRef] {.async: (raises: [CatchableError]).}
 
   # This inheritance arrangement is useful for
   # e.g. combo HTTP server

--- a/json_rpc/servers/httpserver.nim
+++ b/json_rpc/servers/httpserver.nim
@@ -10,7 +10,6 @@
 {.push raises: [], gcsafe.}
 
 import
-  stew/byteutils,
   std/sequtils,
   chronicles, httputils, chronos,
   chronos/apps/http/[httpserver, shttpserver],
@@ -54,7 +53,7 @@ proc serveHTTP*(rpcServer: RpcHttpHandler, request: HttpRequestRef):
       len = req.len
 
     let
-      data = await rpcServer.route(string.fromBytes(req))
+      data = await rpcServer.route(req)
       chunkSize = rpcServer.maxChunkSize
       streamType =
         if data.len <= chunkSize:

--- a/json_rpc/servers/socketserver.nim
+++ b/json_rpc/servers/socketserver.nim
@@ -7,9 +7,13 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
+  std/sequtils,
   chronicles,
   json_serialization/std/net,
+  ../private/utils,
   ../errors,
   ../server
 
@@ -20,20 +24,21 @@ type
     servers: seq[StreamServer]
     processClientHook: StreamCallback2
 
-proc processClient(server: StreamServer, transport: StreamTransport) {.async: (raises: []), gcsafe.} =
+proc processClient(server: StreamServer, transport: StreamTransport) {.async: (raises: []).} =
   ## Process transport data to the RPC server
   try:
     var rpc = getUserData[RpcSocketServer](server)
     while true:
-      var
-        value = await transport.readLine(defaultMaxRequestLength)
-      if value == "":
+      let req = await transport.readLine(defaultMaxRequestLength)
+      if req == "":
         await transport.closeWait()
         break
 
-      debug "Processing message", address = transport.remoteAddress(), line = value
+      debug "Received JSON-RPC request",
+        address = transport.remoteAddress(),
+        len = req.len
 
-      let res = await rpc.route(value)
+      let res = await rpc.route(req)
       discard await transport.write(res & "\r\n")
   except TransportError as ex:
     error "Transport closed during processing client", msg=ex.msg
@@ -42,98 +47,33 @@ proc processClient(server: StreamServer, transport: StreamTransport) {.async: (r
 
 # Utility functions for setting up servers using stream transport addresses
 
-proc addStreamServer*(server: RpcSocketServer, address: TransportAddress) =
+proc addStreamServer*(server: RpcSocketServer, address: TransportAddress) {.raises: [JsonRpcError].} =
   try:
-    info "Starting JSON-RPC socket server", address = $address
     var transportServer = createStreamServer(address, server.processClientHook, {ReuseAddr}, udata = server)
     server.servers.add(transportServer)
   except CatchableError as exc:
     error "Failed to create server", address = $address, message = exc.msg
+    raise newException(RpcBindError, "Unable to create stream server: " & exc.msg)
 
-  if len(server.servers) == 0:
-    # Server was not bound, critical error.
-    raise newException(RpcBindError, "Unable to create server!")
-
-proc addStreamServers*(server: RpcSocketServer, addresses: openArray[TransportAddress]) =
+proc addStreamServers*(server: RpcSocketServer, addresses: openArray[TransportAddress]) {.raises: [JsonRpcError].} =
+  var lastExc: ref JsonRpcError
   for item in addresses:
-    server.addStreamServer(item)
+    try:
+      server.addStreamServer(item)
+    except JsonRpcError as exc:
+      lastExc = exc
+  if server.servers.len == 0:
+    raise lastExc
 
-proc addStreamServer*(server: RpcSocketServer, address: string) =
+proc addStreamServer*(server: RpcSocketServer, address: string) {.raises: [JsonRpcError].} =
   ## Create new server and assign it to addresses ``addresses``.
-  var
-    tas4: seq[TransportAddress]
-    tas6: seq[TransportAddress]
-    added = 0
+  addStreamServers(server, toSeq(resolveIP([address])))
 
-  # Attempt to resolve `address` for IPv4 address space.
-  try:
-    tas4 = resolveTAddress(address, AddressFamily.IPv4)
-  except CatchableError:
-    discard
-  except Defect:
-    discard
+proc addStreamServers*(server: RpcSocketServer, addresses: openArray[string]) {.raises: [JsonRpcError].} =
+  addStreamServers(server, toSeq(resolveIP(addresses)))
 
-  # Attempt to resolve `address` for IPv6 address space.
-  try:
-    tas6 = resolveTAddress(address, AddressFamily.IPv6)
-  except CatchableError:
-    discard
-  except Defect:
-    discard
-
-  for r in tas4:
-    server.addStreamServer(r)
-    added.inc
-  for r in tas6:
-    server.addStreamServer(r)
-    added.inc
-
-  if added == 0:
-    # Addresses could not be resolved, critical error.
-    raise newException(RpcAddressUnresolvableError, "Unable to get address!")
-
-proc addStreamServers*(server: RpcSocketServer, addresses: openArray[string]) =
-  for address in addresses:
-    server.addStreamServer(address)
-
-proc addStreamServer*(server: RpcSocketServer, address: string, port: Port) =
-  var
-    tas4: seq[TransportAddress]
-    tas6: seq[TransportAddress]
-    added = 0
-
-  # Attempt to resolve `address` for IPv4 address space.
-  try:
-    tas4 = resolveTAddress(address, port, AddressFamily.IPv4)
-  except CatchableError:
-    discard
-  except Defect:
-    discard
-
-  # Attempt to resolve `address` for IPv6 address space.
-  try:
-    tas6 = resolveTAddress(address, port, AddressFamily.IPv6)
-  except CatchableError:
-    discard
-  except Defect:
-    discard
-
-  if len(tas4) == 0 and len(tas6) == 0:
-    # Address was not resolved, critical error.
-    raise newException(RpcAddressUnresolvableError,
-                       "Address " & address & " could not be resolved!")
-
-  for r in tas4:
-    server.addStreamServer(r)
-    added.inc
-  for r in tas6:
-    server.addStreamServer(r)
-    added.inc
-
-  if len(server.servers) == 0:
-    # Server was not bound, critical error.
-    raise newException(RpcBindError,
-                      "Could not setup server on " & address & ":" & $int(port))
+proc addStreamServer*(server: RpcSocketServer, address: string, port: Port) {.raises: [JsonRpcError].} =
+  addStreamServers(server, toSeq(resolveIP(address, port)))
 
 proc new(T: type RpcSocketServer): T =
   T(router: RpcRouter.init(), servers: @[], processClientHook: processClient)
@@ -141,17 +81,17 @@ proc new(T: type RpcSocketServer): T =
 proc newRpcSocketServer*(): RpcSocketServer =
   RpcSocketServer.new()
 
-proc newRpcSocketServer*(addresses: openArray[TransportAddress]): RpcSocketServer =
+proc newRpcSocketServer*(addresses: openArray[TransportAddress]): RpcSocketServer {.raises: [JsonRpcError].} =
   ## Create new server and assign it to addresses ``addresses``.
   result = RpcSocketServer.new()
   result.addStreamServers(addresses)
 
-proc newRpcSocketServer*(addresses: openArray[string]): RpcSocketServer =
+proc newRpcSocketServer*(addresses: openArray[string]): RpcSocketServer {.raises: [JsonRpcError].} =
   ## Create new server and assign it to addresses ``addresses``.
   result = RpcSocketServer.new()
   result.addStreamServers(addresses)
 
-proc newRpcSocketServer*(address: string, port: Port = Port(8545)): RpcSocketServer =
+proc newRpcSocketServer*(address: string, port: Port = Port(8545)): RpcSocketServer {.raises: [JsonRpcError].} =
   # Create server on specified port
   result = RpcSocketServer.new()
   result.addStreamServer(address, port)
@@ -161,15 +101,23 @@ proc newRpcSocketServer*(processClientHook: StreamCallback2): RpcSocketServer =
   result = RpcSocketServer.new()
   result.processClientHook = processClientHook
 
-proc start*(server: RpcSocketServer) =
+proc start*(server: RpcSocketServer) {.raises: [JsonRpcError].} =
   ## Start the RPC server.
   for item in server.servers:
-    item.start()
+    try:
+      info "Starting JSON-RPC socket server", address = item.localAddress
+      item.start()
+    except TransportOsError as exc:
+      # TODO stop already-started servers
+      raise (ref RpcBindError)(msg: exc.msg, parent: exc)
 
 proc stop*(server: RpcSocketServer) =
   ## Stop the RPC server.
   for item in server.servers:
-    item.stop()
+    try:
+      item.stop()
+    except TransportOsError as exc:
+      warn "Could not stop transport", err = exc.msg
 
 proc close*(server: RpcSocketServer) =
   ## Cleanup resources of RPC server.

--- a/json_rpc/servers/websocketserver.nim
+++ b/json_rpc/servers/websocketserver.nim
@@ -27,7 +27,8 @@ type
   # - true: auth success, continue execution
   # - false: could not authenticate, stop execution
   #   and return the response
-  WsAuthHook* = proc(request: HttpRequest): Future[bool] {.async.}
+  WsAuthHook* =
+    proc(request: HttpRequest): Future[bool] {.async: (raises: [CatchableError]).}
 
   # This inheritance arrangement is useful for
   # e.g. combo HTTP server

--- a/json_rpc/servers/websocketserver.nim
+++ b/json_rpc/servers/websocketserver.nim
@@ -64,7 +64,7 @@ proc serveHTTP*(rpc: RpcWebSocketHandler, request: HttpRequest)
         break
 
       let data = try:
-          await rpc.route(string.fromBytes(req))
+          await rpc.route(req)
         except CatchableError as exc:
           debug "Internal error, while processing RPC call",
             address = $request.uri

--- a/tests/testhook.nim
+++ b/tests/testhook.nim
@@ -25,8 +25,7 @@ proc authHeaders(): seq[(string, string)] =
   @[("Auth-Token", "Good Token")]
 
 suite "HTTP server hook test":
-  proc mockAuth(req: HttpRequestRef): Future[HttpResponseRef] {.
-        gcsafe, async: (raises: [CatchableError]).} =
+  proc mockAuth(req: HttpRequestRef): Future[HttpResponseRef] {.async.} =
     if req.headers.getString("Auth-Token") == "Good Token":
       return HttpResponseRef(nil)
 

--- a/tests/testhook.nim
+++ b/tests/testhook.nim
@@ -25,7 +25,7 @@ proc authHeaders(): seq[(string, string)] =
   @[("Auth-Token", "Good Token")]
 
 suite "HTTP server hook test":
-  proc mockAuth(req: HttpRequestRef): Future[HttpResponseRef] {.async.} =
+  proc mockAuth(req: HttpRequestRef): Future[HttpResponseRef] {.async: (raises: [CatchableError]).} =
     if req.headers.getString("Auth-Token") == "Good Token":
       return HttpResponseRef(nil)
 

--- a/tests/testhook.nim
+++ b/tests/testhook.nim
@@ -59,7 +59,7 @@ proc wsAuthHeaders(ctx: Hook,
 suite "Websocket server hook test":
   let hook = Hook(append: wsAuthHeaders)
 
-  proc mockAuth(req: websock.HttpRequest): Future[bool] {.async.} =
+  proc mockAuth(req: websock.HttpRequest): Future[bool] {.async: (raises: [CatchableError]).} =
     if not req.headers.contains("Auth-Token"):
       await req.sendResponse(code = Http403, data = "Missing Auth-Token")
       return false

--- a/tests/testhttp.nim
+++ b/tests/testhttp.nim
@@ -8,80 +8,67 @@
 # those terms.
 
 import
-  unittest2,
+  unittest2, chronos/unittest2/asynctests,
   ../json_rpc/[rpcserver, rpcclient, jsonmarshal]
 
 const TestsCount = 100
-
-proc simpleTest(address: string): Future[bool] {.async.} =
-  var client = newRpcHttpClient()
-  await client.connect("http://" & address)
-  var r = await client.call("noParamsProc", %[])
-  if r.string == "\"Hello world\"":
-    result = true
-
-proc continuousTest(address: string): Future[int] {.async.} =
-  var client = newRpcHttpClient()
-  result = 0
-  for i in 0..<TestsCount:
-    await client.connect("http://" & address)
-    var r = await client.call("myProc", %[%"abc", %[1, 2, 3, i]])
-    if r.string == "\"Hello abc data: [1, 2, 3, " & $i & "]\"":
-      result += 1
-    await client.close()
-
-proc invalidTest(address: string): Future[bool] {.async.} =
-  var client = newRpcHttpClient()
-  await client.connect("http://" & address)
-  var invalidA, invalidB: bool
-  try:
-    var r = await client.call("invalidProcA", %[])
-    discard r
-  except JsonRpcError:
-    invalidA = true
-  try:
-    var r = await client.call("invalidProcB", %[1, 2, 3])
-    discard r
-  except JsonRpcError:
-    invalidB = true
-  if invalidA and invalidB:
-    result = true
-
 const bigChunkSize = 4 * 8192
 
-proc chunkedTest(address: string): Future[bool] {.async.} =
-  var client = newRpcHttpClient()
-  await client.connect("http://" & address)
-  let r = await client.call("bigchunkMethod", %[])
-  let data = JrpcConv.decode(r.string, seq[byte])
-  return data.len == bigChunkSize
+suite "JSON-RPC/http":
+  setup:
+    var httpsrv = newRpcHttpServer(["127.0.0.1:0"])
+    # Create RPC on server
+    httpsrv.rpc("myProc") do(input: string, data: array[0..3, int]):
+      result = %("Hello " & input & " data: " & $data)
+    httpsrv.rpc("noParamsProc") do():
+      result = %("Hello world")
 
-var httpsrv = newRpcHttpServer(["127.0.0.1:0"])
+    httpsrv.rpc("bigchunkMethod") do() -> seq[byte]:
+      result = newSeq[byte](bigChunkSize)
+      for i in 0..<result.len:
+        result[i] = byte(i mod 255)
 
-# Create RPC on server
-httpsrv.rpc("myProc") do(input: string, data: array[0..3, int]):
-  result = %("Hello " & input & " data: " & $data)
-httpsrv.rpc("noParamsProc") do():
-  result = %("Hello world")
+    httpsrv.setMaxChunkSize(8192)
+    httpsrv.start()
+    let serverAddress = $httpsrv.localAddress()[0]
 
-httpsrv.rpc("bigchunkMethod") do() -> seq[byte]:
-  result = newSeq[byte](bigChunkSize)
-  for i in 0..<result.len:
-    result[i] = byte(i mod 255)
+  teardown:
+    waitFor httpsrv.stop()
+    waitFor httpsrv.closeWait()
 
-httpsrv.setMaxChunkSize(8192)
-httpsrv.start()
-let serverAddress = $httpsrv.localAddress()[0]
+  asyncTest "Simple RPC call":
+    var client = newRpcHttpClient()
+    await client.connect("http://" & serverAddress)
 
-suite "JSON-RPC test suite":
-  test "Simple RPC call":
-    check waitFor(simpleTest(serverAddress)) == true
-  test "Continuous RPC calls (" & $TestsCount & " messages)":
-    check waitFor(continuousTest(serverAddress)) == TestsCount
-  test "Invalid RPC calls":
-    check waitFor(invalidTest(serverAddress)) == true
-  test "Http client can handle chunked transfer encoding":
-    check waitFor(chunkedTest(serverAddress)) == true
+    var r = await client.call("noParamsProc", %[])
+    check r.string == "\"Hello world\""
+    await client.close()
 
-waitFor httpsrv.stop()
-waitFor httpsrv.closeWait()
+  asyncTest "Continuous RPC calls (" & $TestsCount & " messages)":
+    var client = newRpcHttpClient()
+    for i in 0..<TestsCount:
+      await client.connect("http://" & serverAddress)
+      var r = await client.call("myProc", %[%"abc", %[1, 2, 3, i]])
+      check: r.string == "\"Hello abc data: [1, 2, 3, " & $i & "]\""
+      await client.close()
+
+  asyncTest "Invalid RPC calls":
+    var client = newRpcHttpClient()
+    await client.connect("http://" & serverAddress)
+    expect JsonRpcError:
+      discard await client.call("invalidProcA", %[])
+
+    expect JsonRpcError:
+      discard await client.call("invalidProcB", %[1, 2, 3])
+
+    await client.close()
+
+  asyncTest "Http client can handle chunked transfer encoding":
+    var client = newRpcHttpClient()
+    await client.connect("http://" & serverAddress)
+    let r = await client.call("bigchunkMethod", %[])
+    let data = JrpcConv.decode(r.string, seq[byte])
+    check:
+      data.len == bigChunkSize
+
+    await client.close()

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -117,10 +117,10 @@ suite "Websocket Server/Client RPC with Compression":
 suite "Custom processClient":
   test "Should be able to use custom processClient":
     var wasCalled: bool = false
-    
-    proc processClientHook(server: StreamServer, transport: StreamTransport) {.async: (raises: []), gcsafe.} =
+
+    proc processClientHook(server: StreamServer, transport: StreamTransport) {.async: (raises: []).} =
       wasCalled = true
-    
+
     var srv = newRpcSocketServer(processClientHook)
     srv.addStreamServer("localhost", Port(8888))
     var client = newRpcSocketClient()


### PR DESCRIPTION
* remove redundant gcsafe/raises
* rework async raises to chronos 4.0 where this was not yet done
* streamline logging between http/socket/ws
  * don't log error when raising exceptions (whoever handles should log)
  * debug-log requests in all variants of server and client
* unify ipv4/ipv6 address resolution, with preference for ipv6
* fix server start so that it consistently raises only when no addresses could be bound
* also return response from `serveHTTP` when using chunked encoding