### PR TITLE
Transform client and server result wrapper from macro to template

### DIFF
--- a/json_rpc/private/shared_wrapper.nim
+++ b/json_rpc/private/shared_wrapper.nim
@@ -1,5 +1,5 @@
 # json-rpc
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -32,11 +32,10 @@ func ensureReturnType*(params: NimNode): NimNode =
 
   params
 
-func noWrap*(returnType: NimNode): bool =
+template noWrap*(returnType: type): auto =
   ## Condition when return type should not be encoded
   ## to Json
-  returnType.repr == "JsonString" or
-    returnType.repr == "JsonString"
+  returnType is JsonString
 
 func paramsTx*(params: JsonNode): RequestParamsTx =
   if params.kind == JArray:

--- a/tests/test_callsigs.nim
+++ b/tests/test_callsigs.nim
@@ -1,5 +1,5 @@
 # json-rpc
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -21,10 +21,7 @@ type
   RefObject = ref object
     name: string
 
-template derefType(T: type): untyped =
-  typeof(T()[])
-
-derefType(RefObject).useDefaultSerializationIn JrpcConv
+RefObject.useDefaultSerializationIn JrpcConv
 
 createRpcSigs(RpcClient, sourceDir & "/private/file_callsigs.nim")
 


### PR DESCRIPTION
Initially only want to fix this weird function, probably leftover from past refactoring:

```Nim
func noWrap*(returnType: NimNode): bool =
  ## Condition when return type should not be encoded
  ## to Json
  returnType.repr == "JsonString" or
    returnType.repr == "JsonString"
```

But then I decide to improve the comparison. Rather than text based comparison, I tell te compiler to compare the type instead. With this PR, the comparison is delegated to template and not by the wrapper macro anymore.