### PR TITLE
don't skip Optional==none/null fields in JSON-RPC writing

### DIFF
--- a/json_rpc.nimble
+++ b/json_rpc.nimble
@@ -1,5 +1,5 @@
 # json-rpc
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -35,7 +35,7 @@ let verbose = getEnv("V", "") notin ["", "0"]
 
 let cfg =
   " --styleCheck:usages --styleCheck:error" &
-  (if verbose: "" else: " --verbosity:0 --hints:off") &
+  (if verbose: "" else: " --verbosity:0") &
   " --skipParentCfg --skipUserCfg --outdir:build --nimcache:build/nimcache -f" &
   " --threads:on -d:chronicles_log_level=ERROR"
 

--- a/json_rpc/jsonmarshal.nim
+++ b/json_rpc/jsonmarshal.nim
@@ -1,5 +1,5 @@
 # json-rpc
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -18,9 +18,9 @@ export
 createJsonFlavor JrpcConv,
   automaticObjectSerialization = false,
   requireAllFields = false,
-  omitOptionalFields = true, # Skip optional fields==none in Writer
+  omitOptionalFields = false, # Don't skip optional fields==none in Writer
   allowUnknownFields = true,
-  skipNullFields = true      # Skip optional fields==null in Reader
+  skipNullFields = true       # Skip optional fields==null in Reader
 
 # JrpcConv is a namespace/flavor for encoding and decoding
 # parameters and return value of a rpc method.

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -14,7 +14,7 @@ import
   ./shared_wrapper,
   ./jrpc_sys
 
-proc createRpcProc(procName, parameters, callBody: NimNode): NimNode =
+func createRpcProc(procName, parameters, callBody: NimNode): NimNode =
   # parameters come as a tree
   var paramList = newSeq[NimNode]()
   for p in parameters: paramList.add(p)
@@ -27,7 +27,7 @@ proc createRpcProc(procName, parameters, callBody: NimNode): NimNode =
   # export this proc
   result[0] = nnkPostfix.newTree(ident"*", newIdentNode($procName))
 
-proc createBatchCallProc(procName, parameters, callBody: NimNode): NimNode =
+func createBatchCallProc(procName, parameters, callBody: NimNode): NimNode =
   # parameters come as a tree
   var paramList = newSeq[NimNode]()
   for p in parameters: paramList.add(p)
@@ -38,7 +38,7 @@ proc createBatchCallProc(procName, parameters, callBody: NimNode): NimNode =
   # export this proc
   result[0] = nnkPostfix.newTree(ident"*", newIdentNode($procName))
 
-proc setupConversion(reqParams, params: NimNode): NimNode =
+func setupConversion(reqParams, params: NimNode): NimNode =
   # populate json params
   # even rpcs with no parameters have an empty json array node sent
 
@@ -59,7 +59,7 @@ template maybeUnwrapClientResult*(client, meth, reqParams, returnType): auto =
     let res = await client.call(meth, reqParams)
     decode(JrpcConv, res.string, typeof returnType)
 
-proc createRpcFromSig*(clientType, rpcDecl: NimNode, alias = NimNode(nil)): NimNode =
+func createRpcFromSig*(clientType, rpcDecl: NimNode, alias = NimNode(nil)): NimNode =
   ## This procedure will generate something like this:
   ## - Currently it always send positional parameters to the server
   ##
@@ -134,7 +134,7 @@ proc createRpcFromSig*(clientType, rpcDecl: NimNode, alias = NimNode(nil)): NimN
   when defined(nimDumpRpcs):
     echo pathStr, ":\n", result.repr
 
-proc processRpcSigs*(clientType, parsedCode: NimNode): NimNode =
+func processRpcSigs*(clientType, parsedCode: NimNode): NimNode =
   result = newStmtList()
 
   for line in parsedCode:
@@ -142,7 +142,7 @@ proc processRpcSigs*(clientType, parsedCode: NimNode): NimNode =
       var procDef = createRpcFromSig(clientType, line)
       result.add(procDef)
 
-proc cresteSignaturesFromString*(clientType: NimNode, sigStrings: string): NimNode =
+func cresteSignaturesFromString*(clientType: NimNode, sigStrings: string): NimNode =
   try:
     result = processRpcSigs(clientType, sigStrings.parseStmt())
   except ValueError as exc:

--- a/json_rpc/private/jrpc_sys.nim
+++ b/json_rpc/private/jrpc_sys.nim
@@ -1,5 +1,5 @@
 # json-rpc
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -308,7 +308,7 @@ proc readValue*(r: var JsonReader[JrpcSys], val: var ResponseBatchRx)
   else:
     r.raiseUnexpectedValue("ResponseBatch must be either array or object, got=" & $tok)
 
-proc toTx*(params: RequestParamsRx): RequestParamsTx =
+func toTx*(params: RequestParamsRx): RequestParamsTx =
   case params.kind:
   of rpPositional:
     result = RequestParamsTx(kind: rpPositional)


### PR DESCRIPTION
Several aspects of the engine API require encoding `null` values explicitly rather than implicitly.

https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/common.md#errors
> Each error returns a `null` `data` value, except `-32000` which returns the `data` object with a `err` member that explains the error encountered.

https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#payload-validation
>   * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` **MUST** be:
>    - The block hash of the ancestor of the invalid payload satisfying the following two conditions:
>      - It is fully validated and deemed `VALID`
>      - Any other ancestor of the invalid payload with a higher `blockNumber` is `INVALID`
>    - `0x0000000000000000000000000000000000000000000000000000000000000000` if the above conditions are satisfied by a PoW block.
>    - `null` if client software cannot determine the ancestor of the invalid
>      payload satisfying the above conditions.

https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#specification
> 5. Client software **MUST** respond to this method call in the following way:
>  * `{status: INVALID_BLOCK_HASH, latestValidHash: null, validationError: errorMessage | null}` if the `blockHash` validation has failed
>  * `{status: INVALID, latestValidHash: 0x0000000000000000000000000000000000000000000000000000000000000000, validationError: errorMessage | null}` if terminal block conditions are not satisfied
>  * `{status: SYNCING, latestValidHash: null, validationError: null}` if requisite data for the payload's acceptance or validation is missing
>  * with the payload status obtained from the [Payload validation](#payload-validation) process if the payload has been fully validated while processing the call
>  * `{status: ACCEPTED, latestValidHash: null, validationError: null}` if the following conditions are met:
>    - the `blockHash` of the payload is valid
>    - the payload doesn't extend the canonical chain
>    - the payload hasn't been fully validated
>    - ancestors of a payload are known and comprise a well-formed chain.

https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#specification-1
> 2. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` references a `VALID` ancestor of the head of canonical chain, i.e. the ancestor passed [payload validation](#payload-validation) process and deemed `VALID`. In the case of such an event, client software **MUST** return `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`.
>
> ...
>
> 8. Client software **MUST** respond to this method call in the following way:
>  * `{payloadStatus: {status: SYNCING, latestValidHash: null, validationError: null}, payloadId: null}` if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because requisite data for the validation is missing
>  * `{payloadStatus: {status: INVALID, latestValidHash: validHash, validationError: errorMessage | null}, payloadId: null}` obtained from the [Payload validation](#payload-validation) process if the payload is deemed `INVALID`
>  * `{payloadStatus: {status: INVALID, latestValidHash: 0x0000000000000000000000000000000000000000000000000000000000000000, validationError: errorMessage | null}, payloadId: null}` obtained either from the [Payload validation](#payload-validation) process or as a result of validating a terminal PoW block referenced by `forkchoiceState.headBlockHash`
>  * `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}` if the payload is deemed `VALID` and a build process hasn't been started
>  * `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: buildProcessId}` if the payload is deemed `VALID` and the build process has begun

https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#specification
> 2. Client software **MUST** return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the `blockHash` validation has failed.

https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#specification-3
> 1. Client software **MUST** place responses in the order given in the request, using `null` for any missing blocks. For instance, if the request is `[A.block_hash, B.block_hash, C.block_hash]` and client software has data of payloads `A` and `C`, but doesn't have data of `B`, the response **MUST** be `[A.body, null, C.body]`.
>
> ...
>
> 1. Client software **MUST** set `withdrawals` field to `null` for bodies of pre-Shanghai blocks.

https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#specification-4
> 1. Client software **MUST** place `null` in the response array for unavailable blocks which numbers are lower than a number of the latest known block. Client software **MUST NOT** return trailing `null` values if the request extends past the current latest known block. Execution Layer client software is expected to download and carry the full block history until EIP-4444 or a similar proposal takes into effect. Consider the following response examples:
>    * `[B1.body, B2.body, ..., Bn.body]` -- entire requested range is filled with block bodies,
>    * `[null, null, B3.body, ..., Bn.body]` -- first two blocks are unavailable (either pruned or not yet downloaded),
>    * `[null, null, ..., null]` -- requested range is behind the latest known block and all blocks are unavailable,
>    * `[B1.body, B2.body, B3.body, B4.body]` -- `B4` is the latest known block and trailing `null` values are trimmed,
>    * `[]` -- entire requested range is beyond the latest known block,
>    * `[null, null, B3.body, B4.body]` -- first two blocks are unavailable, `B4` is the latest known block.
>
> 1. Client software **MUST** set `withdrawals` field to `null` for bodies of pre-Shanghai blocks.

https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/cancun.md#specification
> 3. Given the expected array of blob versioned hashes client software **MUST** run its validation by taking the following steps:
>    ...
>    2. Return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the expected and the actual arrays don't match.
