### PR TITLE
Fix #239; Allow custom JSON flavors for "client" code

### DIFF
--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -377,7 +377,7 @@ macro createRpcSigsFromString*(Format: type SerializationFormat, clientType: unt
 template createRpcSigsFromString*(clientType: untyped, sigString: string): untyped =
   createRpcSigsFromString(JrpcConv, clientType, sigString)
 
-macro createSingleRpcSig*(clientType: untyped, alias: static[string], procDecl: untyped): untyped =
+macro createSingleRpcSig*(Format: type SerializationFormat, clientType: untyped, alias: static[string], procDecl: untyped): untyped =
   ## Takes a single forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
@@ -385,7 +385,10 @@ macro createSingleRpcSig*(clientType: untyped, alias: static[string], procDecl: 
   doAssert procDecl.len == 1, "Only accept single proc definition"
   let procDecl = procDecl[0]
   procDecl.expectKind nnkProcDef
-  result = createRpcFromSig(clientType, procDecl, ident(alias))
+  result = createRpcFromSig(clientType, procDecl, Format, ident(alias))
+
+template createSingleRpcSig*(clientType: untyped, alias: string, procDecl: untyped): untyped =
+  createSingleRpcSig(JrpcConv, clientType, alias, procDecl)
 
 macro createRpcSigsFromNim*(Format: type SerializationFormat, clientType: untyped, procList: untyped): untyped =
   ## Takes a list of forward declarations in Nim and builds them into RPC

--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -239,9 +239,14 @@ proc call*(
   client.complete(req, id)
 
 proc call*(
+    client: RpcClient, name: string, params: JsonNode, Flavor: type SerializationFormat
+): Future[JsonString] {.async: (raises: [CancelledError, JsonRpcError], raw: true).} =
+  client.call(name, paramsTx(params, Flavor))
+
+proc call*(
     client: RpcClient, name: string, params: JsonNode
 ): Future[JsonString] {.async: (raises: [CancelledError, JsonRpcError], raw: true).} =
-  client.call(name, params.paramsTx)
+  client.call(name, paramsTx(params, JrpcConv))
 
 proc callBatch*(
     client: RpcClient, calls: seq[RequestTx]

--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -357,27 +357,27 @@ proc send*(
 # Signature processing
 # ------------------------------------------------------------------------------
 
-macro createRpcSigs*(Format: type SerializationFormat, clientType: untyped, filePath: static[string]): untyped =
+macro createRpcSigs*(clientType: untyped, filePath: static[string], flavorType: untyped): untyped =
   ## Takes a file of forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
   ## Nim type.
-  cresteSignaturesFromString(clientType, staticRead($filePath.replace('\\', '/')), Format)
+  cresteSignaturesFromString(clientType, staticRead($filePath.replace('\\', '/')), flavorType)
 
 template createRpcSigs*(clientType: untyped, filePath: string): untyped =
-  createRpcSigs(JrpcConv, clientType, filePath)
+  createRpcSigs(clientType, filePath, JrpcConv)
 
-macro createRpcSigsFromString*(Format: type SerializationFormat, clientType: untyped, sigString: static[string]): untyped =
+macro createRpcSigsFromString*(clientType: untyped, sigString: static[string], flavorType: untyped): untyped =
   ## Takes a string of forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
   ## Nim type.
-  cresteSignaturesFromString(clientType, sigString, Format)
+  cresteSignaturesFromString(clientType, sigString, flavorType)
 
 template createRpcSigsFromString*(clientType: untyped, sigString: string): untyped =
-  createRpcSigsFromString(JrpcConv, clientType, sigString)
+  createRpcSigsFromString(clientType, sigString, JrpcConv)
 
-macro createSingleRpcSig*(Format: type SerializationFormat, clientType: untyped, alias: static[string], procDecl: untyped): untyped =
+macro createSingleRpcSig*(clientType: untyped, alias: static[string], flavorType, procDecl: untyped): untyped =
   ## Takes a single forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
@@ -385,19 +385,19 @@ macro createSingleRpcSig*(Format: type SerializationFormat, clientType: untyped,
   doAssert procDecl.len == 1, "Only accept single proc definition"
   let procDecl = procDecl[0]
   procDecl.expectKind nnkProcDef
-  result = createRpcFromSig(clientType, procDecl, Format, ident(alias))
+  result = createRpcFromSig(clientType, procDecl, flavorType, ident(alias))
 
 template createSingleRpcSig*(clientType: untyped, alias: string, procDecl: untyped): untyped =
-  createSingleRpcSig(JrpcConv, clientType, alias, procDecl)
+  createSingleRpcSig(clientType, alias, JrpcConv, procDecl)
 
-macro createRpcSigsFromNim*(Format: type SerializationFormat, clientType: untyped, procList: untyped): untyped =
+macro createRpcSigsFromNim*(clientType, flavorType, procList: untyped): untyped =
   ## Takes a list of forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
   ## Nim type.
-  processRpcSigs(clientType, procList, Format)
+  processRpcSigs(clientType, procList, flavorType)
 
-template createRpcSigsFromNim*(clientType: untyped, procList: untyped): untyped =
-  createRpcSigsFromNim(JrpcConv, clientType, procList)
+template createRpcSigsFromNim*(clientType, procList: untyped): untyped =
+  createRpcSigsFromNim(clientType, JrpcConv, procList)
 
 {.pop.}

--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -239,9 +239,9 @@ proc call*(
   client.complete(req, id)
 
 proc call*(
-    client: RpcClient, name: string, params: JsonNode, Flavor: type SerializationFormat
+    client: RpcClient, name: string, params: JsonNode, Format: type SerializationFormat
 ): Future[JsonString] {.async: (raises: [CancelledError, JsonRpcError], raw: true).} =
-  client.call(name, paramsTx(params, Flavor))
+  client.call(name, paramsTx(params, Format))
 
 proc call*(
     client: RpcClient, name: string, params: JsonNode
@@ -362,27 +362,27 @@ proc send*(
 # Signature processing
 # ------------------------------------------------------------------------------
 
-macro createRpcSigs*(clientType: untyped, filePath: static[string], flavorType: untyped): untyped =
+macro createRpcSigs*(clientType: untyped, filePath: static[string], formatType: untyped): untyped =
   ## Takes a file of forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
   ## Nim type.
-  cresteSignaturesFromString(clientType, staticRead($filePath.replace('\\', '/')), flavorType)
+  cresteSignaturesFromString(clientType, staticRead($filePath.replace('\\', '/')), formatType)
 
 template createRpcSigs*(clientType: untyped, filePath: string): untyped =
   createRpcSigs(clientType, filePath, JrpcConv)
 
-macro createRpcSigsFromString*(clientType: untyped, sigString: static[string], flavorType: untyped): untyped =
+macro createRpcSigsFromString*(clientType: untyped, sigString: static[string], formatType: untyped): untyped =
   ## Takes a string of forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
   ## Nim type.
-  cresteSignaturesFromString(clientType, sigString, flavorType)
+  cresteSignaturesFromString(clientType, sigString, formatType)
 
 template createRpcSigsFromString*(clientType: untyped, sigString: string): untyped =
   createRpcSigsFromString(clientType, sigString, JrpcConv)
 
-macro createSingleRpcSig*(clientType: untyped, alias: static[string], flavorType, procDecl: untyped): untyped =
+macro createSingleRpcSig*(clientType: untyped, alias: static[string], formatType, procDecl: untyped): untyped =
   ## Takes a single forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
@@ -390,17 +390,17 @@ macro createSingleRpcSig*(clientType: untyped, alias: static[string], flavorType
   doAssert procDecl.len == 1, "Only accept single proc definition"
   let procDecl = procDecl[0]
   procDecl.expectKind nnkProcDef
-  result = createRpcFromSig(clientType, procDecl, flavorType, ident(alias))
+  result = createRpcFromSig(clientType, procDecl, formatType, ident(alias))
 
 template createSingleRpcSig*(clientType: untyped, alias: string, procDecl: untyped): untyped =
   createSingleRpcSig(clientType, alias, JrpcConv, procDecl)
 
-macro createRpcSigsFromNim*(clientType, flavorType, procList: untyped): untyped =
+macro createRpcSigsFromNim*(clientType, formatType, procList: untyped): untyped =
   ## Takes a list of forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
   ## Nim type.
-  processRpcSigs(clientType, procList, flavorType)
+  processRpcSigs(clientType, procList, formatType)
 
 template createRpcSigsFromNim*(clientType, procList: untyped): untyped =
   createRpcSigsFromNim(clientType, JrpcConv, procList)

--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -357,19 +357,25 @@ proc send*(
 # Signature processing
 # ------------------------------------------------------------------------------
 
-macro createRpcSigs*(clientType: untyped, filePath: static[string]): untyped =
+macro createRpcSigs*(Format: type SerializationFormat, clientType: untyped, filePath: static[string]): untyped =
   ## Takes a file of forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
   ## Nim type.
-  cresteSignaturesFromString(clientType, staticRead($filePath.replace('\\', '/')))
+  cresteSignaturesFromString(clientType, staticRead($filePath.replace('\\', '/')), Format)
 
-macro createRpcSigsFromString*(clientType: untyped, sigString: static[string]): untyped =
+template createRpcSigs*(clientType: untyped, filePath: string): untyped =
+  createRpcSigs(JrpcConv, clientType, filePath)
+
+macro createRpcSigsFromString*(Format: type SerializationFormat, clientType: untyped, sigString: static[string]): untyped =
   ## Takes a string of forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
   ## Nim type.
-  cresteSignaturesFromString(clientType, sigString)
+  cresteSignaturesFromString(clientType, sigString, Format)
+
+template createRpcSigsFromString*(clientType: untyped, sigString: string): untyped =
+  createRpcSigsFromString(JrpcConv, clientType, sigString)
 
 macro createSingleRpcSig*(clientType: untyped, alias: static[string], procDecl: untyped): untyped =
   ## Takes a single forward declarations in Nim and builds them into RPC
@@ -381,11 +387,14 @@ macro createSingleRpcSig*(clientType: untyped, alias: static[string], procDecl: 
   procDecl.expectKind nnkProcDef
   result = createRpcFromSig(clientType, procDecl, ident(alias))
 
-macro createRpcSigsFromNim*(clientType: untyped, procList: untyped): untyped =
+macro createRpcSigsFromNim*(Format: type SerializationFormat, clientType: untyped, procList: untyped): untyped =
   ## Takes a list of forward declarations in Nim and builds them into RPC
   ## calls, based on their parameters.
   ## Inputs are marshalled to json, and results are put into the signature's
   ## Nim type.
-  processRpcSigs(clientType, procList)
+  processRpcSigs(clientType, procList, Format)
+
+template createRpcSigsFromNim*(clientType: untyped, procList: untyped): untyped =
+  createRpcSigsFromNim(JrpcConv, clientType, procList)
 
 {.pop.}

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -36,7 +36,7 @@ func createBatchCallProc(procName, parameters, callBody: NimNode): NimNode =
   # export this proc
   result[0] = nnkPostfix.newTree(ident"*", newIdentNode($procName))
 
-func setupConversion(reqParams, params: NimNode): NimNode =
+func setupConversion(reqParams, params, Format: NimNode): NimNode =
   # populate json params
   # even rpcs with no parameters have an empty json array node sent
 
@@ -47,20 +47,20 @@ func setupConversion(reqParams, params: NimNode): NimNode =
 
   for parIdent, _, parType in paramsIter(params):
     result.add quote do:
-      `reqParams`.positional.add encode(JrpcConv, `parIdent`).JsonString
+      `reqParams`.positional.add encode(`Format`, `parIdent`).JsonString
 
-template maybeUnwrapClientResult*(client, meth, reqParams, returnType): auto =
+template maybeUnwrapClientResult*(client, meth, reqParams, returnType, Format): auto =
   ## Don't decode e.g. JsonString, return as is
   when noWrap(returnType):
     client.call(meth, reqParams)
   else:
     proc complete(f: auto): Future[returnType] {.async.} =
       let res = await f
-      decode(JrpcConv, res.string, returnType)
+      decode(Format, res.string, returnType)
     let fut = client.call(meth, reqParams)
     complete(fut)
 
-func createRpcFromSig*(clientType, rpcDecl: NimNode, alias = NimNode(nil)): NimNode =
+func createRpcFromSig*(clientType, rpcDecl, Format: NimNode, alias = NimNode(nil)): NimNode =
   ## This procedure will generate something like this:
   ## - Currently it always send positional parameters to the server
   ##
@@ -89,7 +89,7 @@ func createRpcFromSig*(clientType, rpcDecl: NimNode, alias = NimNode(nil)): NimN
     pathStr = $rpcDecl.name
     returnType = params[0]
     reqParams = ident "reqParams"
-    setup = setupConversion(reqParams, params)
+    setup = setupConversion(reqParams, params, Format)
     clientIdent = ident"client"
     batchParams = params.copy
     batchIdent = ident "batch"
@@ -108,7 +108,7 @@ func createRpcFromSig*(clientType, rpcDecl: NimNode, alias = NimNode(nil)): NimN
   let callBody = quote do:
     # populate request params
     `setup`
-    maybeUnwrapClientResult(`clientIdent`, `pathStr`, `reqParams`, `returnType`)
+    maybeUnwrapClientResult(`clientIdent`, `pathStr`, `reqParams`, `returnType`, `Format`)
 
   # insert RpcBatchCallRef as first parameter
   batchParams.insert(1, nnkIdentDefs.newTree(
@@ -135,17 +135,17 @@ func createRpcFromSig*(clientType, rpcDecl: NimNode, alias = NimNode(nil)): NimN
   when defined(nimDumpRpcs):
     debugEcho pathStr, ":\n", result.repr
 
-func processRpcSigs*(clientType, parsedCode: NimNode): NimNode =
+func processRpcSigs*(clientType, parsedCode, Format: NimNode): NimNode =
   result = newStmtList()
 
   for line in parsedCode:
     if line.kind == nnkProcDef:
-      var procDef = createRpcFromSig(clientType, line)
+      var procDef = createRpcFromSig(clientType, line, Format)
       result.add(procDef)
 
-func cresteSignaturesFromString*(clientType: NimNode, sigStrings: string): NimNode =
+func cresteSignaturesFromString*(clientType: NimNode, sigStrings: string, Format: NimNode): NimNode =
   try:
-    result = processRpcSigs(clientType, sigStrings.parseStmt())
+    result = processRpcSigs(clientType, sigStrings.parseStmt(), Format)
   except ValueError as exc:
     doAssert(false, exc.msg)
 

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -36,7 +36,7 @@ func createBatchCallProc(procName, parameters, callBody: NimNode): NimNode =
   # export this proc
   result[0] = nnkPostfix.newTree(ident"*", newIdentNode($procName))
 
-func setupConversion(reqParams, params, flavorType: NimNode): NimNode =
+func setupConversion(reqParams, params, formatType: NimNode): NimNode =
   # populate json params
   # even rpcs with no parameters have an empty json array node sent
 
@@ -47,20 +47,20 @@ func setupConversion(reqParams, params, flavorType: NimNode): NimNode =
 
   for parIdent, _, parType in paramsIter(params):
     result.add quote do:
-      `reqParams`.positional.add encode(`flavorType`, `parIdent`).JsonString
+      `reqParams`.positional.add encode(`formatType`, `parIdent`).JsonString
 
-template maybeUnwrapClientResult*(client, meth, reqParams, returnType, flavorType): auto =
+template maybeUnwrapClientResult*(client, meth, reqParams, returnType, formatType): auto =
   ## Don't decode e.g. JsonString, return as is
   when noWrap(returnType):
     client.call(meth, reqParams)
   else:
     proc complete(f: auto): Future[returnType] {.async.} =
       let res = await f
-      decode(flavorType, res.string, returnType)
+      decode(formatType, res.string, returnType)
     let fut = client.call(meth, reqParams)
     complete(fut)
 
-func createRpcFromSig*(clientType, rpcDecl, flavorType: NimNode, alias = NimNode(nil)): NimNode =
+func createRpcFromSig*(clientType, rpcDecl, formatType: NimNode, alias = NimNode(nil)): NimNode =
   ## This procedure will generate something like this:
   ## - Currently it always send positional parameters to the server
   ##
@@ -89,7 +89,7 @@ func createRpcFromSig*(clientType, rpcDecl, flavorType: NimNode, alias = NimNode
     pathStr = $rpcDecl.name
     returnType = params[0]
     reqParams = ident "reqParams"
-    setup = setupConversion(reqParams, params, flavorType)
+    setup = setupConversion(reqParams, params, formatType)
     clientIdent = ident"client"
     batchParams = params.copy
     batchIdent = ident "batch"
@@ -108,7 +108,7 @@ func createRpcFromSig*(clientType, rpcDecl, flavorType: NimNode, alias = NimNode
   let callBody = quote do:
     # populate request params
     `setup`
-    maybeUnwrapClientResult(`clientIdent`, `pathStr`, `reqParams`, `returnType`, `flavorType`)
+    maybeUnwrapClientResult(`clientIdent`, `pathStr`, `reqParams`, `returnType`, `formatType`)
 
   # insert RpcBatchCallRef as first parameter
   batchParams.insert(1, nnkIdentDefs.newTree(
@@ -135,17 +135,17 @@ func createRpcFromSig*(clientType, rpcDecl, flavorType: NimNode, alias = NimNode
   when defined(nimDumpRpcs):
     debugEcho pathStr, ":\n", result.repr
 
-func processRpcSigs*(clientType, parsedCode, flavorType: NimNode): NimNode =
+func processRpcSigs*(clientType, parsedCode, formatType: NimNode): NimNode =
   result = newStmtList()
 
   for line in parsedCode:
     if line.kind == nnkProcDef:
-      var procDef = createRpcFromSig(clientType, line, flavorType)
+      var procDef = createRpcFromSig(clientType, line, formatType)
       result.add(procDef)
 
-func cresteSignaturesFromString*(clientType: NimNode, sigStrings: string, flavorType: NimNode): NimNode =
+func cresteSignaturesFromString*(clientType: NimNode, sigStrings: string, formatType: NimNode): NimNode =
   try:
-    result = processRpcSigs(clientType, sigStrings.parseStmt(), flavorType)
+    result = processRpcSigs(clientType, sigStrings.parseStmt(), formatType)
   except ValueError as exc:
     doAssert(false, exc.msg)
 

--- a/json_rpc/private/server_handler_wrapper.nim
+++ b/json_rpc/private/server_handler_wrapper.nim
@@ -12,7 +12,7 @@
 import
   std/[macros, typetraits],
   stew/[byteutils, objects],
-  chronos,
+  chronos/futures,
   json_serialization,
   json_serialization/std/[options],
   json_serialization/pkg/results,
@@ -42,12 +42,12 @@ template rpc_isOptional[T](_: options.Option[T]): bool = true
 # Run time helpers
 # ------------------------------------------------------------------------------
 
-func unpackArg(args: JsonString, argName: string, argType: type, Format: type SerializationFormat): argType
+func unpackArg(args: JsonString, argName: string, argType: type, Flavor: type SerializationFormat): argType
                 {.gcsafe, raises: [JsonRpcError].} =
   ## This where input parameters are decoded from JSON into
   ## Nim data types
   try:
-    result = Format.decode(args.string, argType)
+    result = decode(Flavor, args.string, argType)
   except CatchableError as err:
     raise newException(RequestDecodeError,
       "Parameter [" & argName & "] of type '" &
@@ -128,7 +128,7 @@ template unpackPositional(
     pos: static[int],
     setup: static[RpcSetup],
     paramType: type,
-    Format: type SerializationFormat
+    Flavor: type SerializationFormat
 ) =
   ## Convert a positional parameter from Json into Nim
 
@@ -136,7 +136,7 @@ template unpackPositional(
     {.pragma: redefine.}
 
   template innerNode() {.redefine.} =
-    paramVar = unpackArg(params.val(pos), paramName, paramType, Format)
+    paramVar = unpackArg(params.val(pos), paramName, paramType, Flavor)
 
   # e.g. (A: int, B: Option[int], C: string, D: Option[int], E: Option[string])
   when rpc_isOptional(paramVar):
@@ -192,14 +192,14 @@ func makeHandler(procName, params, procBody, returnInner: NimNode): NimNode =
     pragmas = pragmas
   )
 
-func ofStmt(x, paramsObj, paramIdent, paramName, paramType, Format: NimNode): NimNode =
+func ofStmt(x, paramsObj, paramIdent, paramName, paramType, flavorType: NimNode): NimNode =
   nnkOfBranch.newTree(
     paramName,
     quote do:
-      `paramsObj`.`paramIdent` = unpackArg(`x`.value, `paramName`, `paramType`, `Format`)
+      `paramsObj`.`paramIdent` = unpackArg(`x`.value, `paramName`, `paramType`, `flavorType`)
   )
 
-func setupNamed(paramsObj, paramsIdent, params, Format: NimNode): NimNode =
+func setupNamed(paramsObj, paramsIdent, params, flavorType: NimNode): NimNode =
   let x = ident"x"
 
   var caseStmt = nnkCaseStmt.newTree(
@@ -207,7 +207,7 @@ func setupNamed(paramsObj, paramsIdent, params, Format: NimNode): NimNode =
   )
 
   for paramIdent, paramStr, paramType in paramsIter(params):
-    caseStmt.add ofStmt(x, paramsObj, paramIdent, paramStr, paramType, Format)
+    caseStmt.add ofStmt(x, paramsObj, paramIdent, paramStr, paramType, flavorType)
 
   caseStmt.add nnkElse.newTree(
     quote do: discard
@@ -217,17 +217,17 @@ func setupNamed(paramsObj, paramsIdent, params, Format: NimNode): NimNode =
     for `x` in `paramsIdent`.named:
       `caseStmt`
 
-template maybeWrapServerResult*(Format, resFut): auto =
+template maybeWrapServerResult*(Flavor, resFut): auto =
   ## Don't encode e.g. JsonString, return as is
   type ResType = typeof(await resFut)
   when noWrap(ResType):
     await resFut
   else:
     let res = await resFut
-    JsonString(encode(Format, res))
+    JsonString(encode(Flavor, res))
 
 func wrapServerHandler*(
-    methName: string, params, procBody, procWrapper, Format: NimNode
+    methName: string, params, procBody, procWrapper, flavorType: NimNode
 ): NimNode =
   ## This proc generate something like this:
   ##
@@ -271,7 +271,7 @@ func wrapServerHandler*(
     hasParams = params.len > 1 # not including return type
     rpcSetup = ident"rpcSetup"
     handler = makeHandler(handlerName, params, procBody, returnType)
-    named = setupNamed(paramsObj, paramsIdent, params, Format)
+    named = setupNamed(paramsObj, paramsIdent, params, flavorType)
 
   if hasParams:
     setup.add makeType(typeName, params)
@@ -294,7 +294,7 @@ func wrapServerHandler*(
         `pos`,
         `rpcSetup`,
         `paramType`,
-        `Format`
+        `flavorType`
       )
 
     executeParams.add quote do:
@@ -327,4 +327,4 @@ func wrapServerHandler*(
       # See: https://github.com/nim-lang/Nim/issues/17849
       `setup`
       let resFut = `executeCall`
-      maybeWrapServerResult(`Format`, resFut)
+      maybeWrapServerResult(`flavorType`, resFut)

--- a/json_rpc/private/shared_wrapper.nim
+++ b/json_rpc/private/shared_wrapper.nim
@@ -77,9 +77,6 @@ func paramsTx*(params: JsonNode, Flavor: type SerializationFormat): RequestParam
       positional: @[encode(Flavor, params).JsonString],
     )
 
-func paramsTx*(params: JsonNode): RequestParamsTx =
-  paramsTx(params, JrpcConv)
-
 func requestTx*(name: string, params: sink RequestParamsTx, id: int): RequestTx =
   RequestTx(
     id: Opt.some(RequestId(kind: riNumber, num: id)),

--- a/json_rpc/private/shared_wrapper.nim
+++ b/json_rpc/private/shared_wrapper.nim
@@ -51,11 +51,11 @@ template noWrap*(returnType: type): auto =
   ## to Json
   returnType is JsonString or returnType is void
 
-func paramsTx*(params: JsonNode): RequestParamsTx =
+func paramsTx*(params: JsonNode, Format: type SerializationFormat): RequestParamsTx =
   if params.kind == JArray:
     var args: seq[JsonString]
     for x in params:
-      args.add JrpcConv.encode(x).JsonString
+      args.add encode(Format, x).JsonString
     RequestParamsTx(
       kind: rpPositional,
       positional: system.move(args),
@@ -65,7 +65,7 @@ func paramsTx*(params: JsonNode): RequestParamsTx =
     for k, v in params:
       args.add ParamDescNamed(
         name: k,
-        value: JrpcConv.encode(v).JsonString,
+        value: encode(Format, v).JsonString,
       )
     RequestParamsTx(
       kind: rpNamed,
@@ -74,8 +74,11 @@ func paramsTx*(params: JsonNode): RequestParamsTx =
   else:
     RequestParamsTx(
       kind: rpPositional,
-      positional: @[JrpcConv.encode(params).JsonString],
+      positional: @[encode(Format, params).JsonString],
     )
+
+func paramsTx*(params: JsonNode): RequestParamsTx =
+  paramsTx(params, JrpcConv)
 
 func requestTx*(name: string, params: sink RequestParamsTx, id: int): RequestTx =
   RequestTx(

--- a/json_rpc/private/shared_wrapper.nim
+++ b/json_rpc/private/shared_wrapper.nim
@@ -51,11 +51,11 @@ template noWrap*(returnType: type): auto =
   ## to Json
   returnType is JsonString or returnType is void
 
-func paramsTx*(params: JsonNode, Flavor: type SerializationFormat): RequestParamsTx =
+func paramsTx*(params: JsonNode, Format: type SerializationFormat): RequestParamsTx =
   if params.kind == JArray:
     var args: seq[JsonString]
     for x in params:
-      args.add encode(Flavor, x).JsonString
+      args.add encode(Format, x).JsonString
     RequestParamsTx(
       kind: rpPositional,
       positional: system.move(args),
@@ -65,7 +65,7 @@ func paramsTx*(params: JsonNode, Flavor: type SerializationFormat): RequestParam
     for k, v in params:
       args.add ParamDescNamed(
         name: k,
-        value: encode(Flavor, v).JsonString,
+        value: encode(Format, v).JsonString,
       )
     RequestParamsTx(
       kind: rpNamed,
@@ -74,7 +74,7 @@ func paramsTx*(params: JsonNode, Flavor: type SerializationFormat): RequestParam
   else:
     RequestParamsTx(
       kind: rpPositional,
-      positional: @[encode(Flavor, params).JsonString],
+      positional: @[encode(Format, params).JsonString],
     )
 
 func requestTx*(name: string, params: sink RequestParamsTx, id: int): RequestTx =

--- a/json_rpc/private/shared_wrapper.nim
+++ b/json_rpc/private/shared_wrapper.nim
@@ -51,11 +51,11 @@ template noWrap*(returnType: type): auto =
   ## to Json
   returnType is JsonString or returnType is void
 
-func paramsTx*(params: JsonNode, Format: type SerializationFormat): RequestParamsTx =
+func paramsTx*(params: JsonNode, Flavor: type SerializationFormat): RequestParamsTx =
   if params.kind == JArray:
     var args: seq[JsonString]
     for x in params:
-      args.add encode(Format, x).JsonString
+      args.add encode(Flavor, x).JsonString
     RequestParamsTx(
       kind: rpPositional,
       positional: system.move(args),
@@ -65,7 +65,7 @@ func paramsTx*(params: JsonNode, Format: type SerializationFormat): RequestParam
     for k, v in params:
       args.add ParamDescNamed(
         name: k,
-        value: encode(Format, v).JsonString,
+        value: encode(Flavor, v).JsonString,
       )
     RequestParamsTx(
       kind: rpNamed,
@@ -74,7 +74,7 @@ func paramsTx*(params: JsonNode, Format: type SerializationFormat): RequestParam
   else:
     RequestParamsTx(
       kind: rpPositional,
-      positional: @[encode(Format, params).JsonString],
+      positional: @[encode(Flavor, params).JsonString],
     )
 
 func paramsTx*(params: JsonNode): RequestParamsTx =

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -213,5 +213,7 @@ macro rpc*(server: RpcRouter, formatType, procList: untyped): untyped =
           error "Unsupported rpc proc definition", prc
           ""  # Nim 1.6
       result.add rpcImpl(server, path, formatType, prc)
+    else:
+      error "Only proc definitions are allowed within an rpc context", prc
 
 {.pop.}

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -195,7 +195,9 @@ macro rpc(
   when defined(nimDumpRpcs):
     echo "\n", path, ": ", result.repr
 
-# XXX remove
+template rpc*(server: RpcRouter, path: string, Format, body: untyped): untyped =
+  rpc(Format, server, path, body)
+
 template rpc*(server: RpcRouter, path: string, body: untyped): untyped =
   rpc(JrpcConv, server, path, body)
 

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -170,8 +170,8 @@ proc route*(
 
   string.fromBytes(await router.route(request))
 
-macro rpc(
-    Format: type SerializationFormat, server: RpcRouter, path: static[string], body: untyped
+macro rpc*(
+    server: RpcRouter, path: static[string], flavorType, body: untyped
 ): untyped =
   ## Define a remote procedure call.
   ## Input and return parameters are defined using the ``do`` notation.
@@ -187,7 +187,7 @@ macro rpc(
     procBody = if body.kind == nnkStmtList: body else: body.body
     procWrapper = genSym(nskProc, $path & "_rpcWrapper")
 
-  result = wrapServerHandler($path, params, procBody, procWrapper, Format)
+  result = wrapServerHandler($path, params, procBody, procWrapper, flavorType)
 
   result.add quote do:
     `server`.register(`path`, `procWrapper`)
@@ -195,10 +195,7 @@ macro rpc(
   when defined(nimDumpRpcs):
     echo "\n", path, ": ", result.repr
 
-template rpc*(server: RpcRouter, path: string, Format, body: untyped): untyped =
-  rpc(Format, server, path, body)
-
 template rpc*(server: RpcRouter, path: string, body: untyped): untyped =
-  rpc(JrpcConv, server, path, body)
+  rpc(server, path, JrpcConv, body)
 
 {.pop.}

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -210,7 +210,7 @@ macro rpc*(server: RpcRouter, formatType, procList: untyped): untyped =
         of nnkIdent, nnkAccQuoted:
           $prc[0]
         else:
-          error "Unsupported proc definition", prc
+          error "Unsupported rpc proc definition", prc
           ""  # Nim 1.6
       result.add rpcImpl(server, path, formatType, prc)
 

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -198,4 +198,10 @@ macro rpc*(
 template rpc*(server: RpcRouter, path: string, body: untyped): untyped =
   rpc(server, path, JrpcConv, body)
 
+template rpcContext*(server: RpcRouter, flavor: type SerializationFormat, body: untyped): untyped =
+  block:
+    template rpc(path: string, body2: untyped): untyped =
+      rpc(server, path, flavor, body2)
+    body
+
 {.pop.}

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -198,10 +198,10 @@ macro rpc*(
 template rpc*(server: RpcRouter, path: string, body: untyped): untyped =
   rpc(server, path, JrpcConv, body)
 
-template rpcContext*(server: RpcRouter, flavor: type SerializationFormat, body: untyped): untyped =
+template rpcContext*(server: RpcRouter, Flavor: type SerializationFormat, body: untyped): untyped =
   block:
     template rpc(path: string, body2: untyped): untyped =
-      rpc(server, path, flavor, body2)
+      rpc(server, path, Flavor, body2)
     body
 
 {.pop.}

--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -171,7 +171,7 @@ proc route*(
   string.fromBytes(await router.route(request))
 
 macro rpc*(
-    server: RpcRouter, path: static[string], flavorType, body: untyped
+    server: RpcRouter, path: static[string], formatType, body: untyped
 ): untyped =
   ## Define a remote procedure call.
   ## Input and return parameters are defined using the ``do`` notation.
@@ -187,7 +187,7 @@ macro rpc*(
     procBody = if body.kind == nnkStmtList: body else: body.body
     procWrapper = genSym(nskProc, $path & "_rpcWrapper")
 
-  result = wrapServerHandler($path, params, procBody, procWrapper, flavorType)
+  result = wrapServerHandler($path, params, procBody, procWrapper, formatType)
 
   result.add quote do:
     `server`.register(`path`, `procWrapper`)
@@ -198,10 +198,10 @@ macro rpc*(
 template rpc*(server: RpcRouter, path: string, body: untyped): untyped =
   rpc(server, path, JrpcConv, body)
 
-template rpcContext*(server: RpcRouter, Flavor: type SerializationFormat, body: untyped): untyped =
+template rpcContext*(server: RpcRouter, Format: type SerializationFormat, body: untyped): untyped =
   block:
     template rpc(path: string, body2: untyped): untyped =
-      rpc(server, path, Flavor, body2)
+      rpc(server, path, Format, body2)
     body
 
 {.pop.}

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -115,8 +115,8 @@ template rpc*(server: RpcProxy, path: string, flavorType, body: untyped): untype
 template rpc*(server: RpcProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 
-template rpcContext*(server: RpcProxy, flavor: type SerializationFormat, body: untyped): untyped =
-  server.rpcHttpServer.rpcContext(flavor, body)
+template rpcContext*(server: RpcProxy, Flavor: type SerializationFormat, body: untyped): untyped =
+  server.rpcHttpServer.rpcContext(Flavor, body)
 
 proc registerProxyMethod*(proxy: var RpcProxy, methodName: string) =
   try:

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -109,14 +109,14 @@ proc start*(proxy: RpcProxy) {.async.} =
   proxy.rpcHttpServer.start()
   await proxy.connectToProxy()
 
-template rpc*(server: RpcProxy, path: string, flavorType, body: untyped): untyped =
-  server.rpcHttpServer.rpc(path, flavorType, body)
+template rpc*(server: RpcProxy, path: string, formatType, body: untyped): untyped =
+  server.rpcHttpServer.rpc(path, formatType, body)
 
 template rpc*(server: RpcProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 
-template rpcContext*(server: RpcProxy, Flavor: type SerializationFormat, body: untyped): untyped =
-  server.rpcHttpServer.rpcContext(Flavor, body)
+template rpcContext*(server: RpcProxy, Format: type SerializationFormat, body: untyped): untyped =
+  server.rpcHttpServer.rpcContext(Format, body)
 
 proc registerProxyMethod*(proxy: var RpcProxy, methodName: string) =
   try:

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -115,8 +115,8 @@ template rpc*(server: RpcProxy, path: string, formatType, body: untyped): untype
 template rpc*(server: RpcProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 
-template rpcContext*(server: RpcProxy, Format: type SerializationFormat, body: untyped): untyped =
-  server.rpcHttpServer.rpcContext(Format, body)
+template rpc*(server: RpcProxy, formatType, procList: untyped): untyped =
+  server.rpcHttpServer.rpc(formatType, procList)
 
 proc registerProxyMethod*(proxy: var RpcProxy, methodName: string) =
   try:

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -115,6 +115,9 @@ template rpc*(server: RpcProxy, path: string, flavorType, body: untyped): untype
 template rpc*(server: RpcProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 
+template rpcContext*(server: RpcProxy, flavor: type SerializationFormat, body: untyped): untyped =
+  server.rpcHttpServer.rpcContext(flavor, body)
+
 proc registerProxyMethod*(proxy: var RpcProxy, methodName: string) =
   try:
     proxy.rpcHttpServer.register(methodName, proxyCall(proxy.getClient(), methodName))

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -109,6 +109,9 @@ proc start*(proxy: RpcProxy) {.async.} =
   proxy.rpcHttpServer.start()
   await proxy.connectToProxy()
 
+template rpc*(server: RpcProxy, path: string, Format, body: untyped): untyped =
+  server.rpcHttpServer.rpc(path, Format, body)
+
 template rpc*(server: RpcProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)
 

--- a/json_rpc/rpcproxy.nim
+++ b/json_rpc/rpcproxy.nim
@@ -109,8 +109,8 @@ proc start*(proxy: RpcProxy) {.async.} =
   proxy.rpcHttpServer.start()
   await proxy.connectToProxy()
 
-template rpc*(server: RpcProxy, path: string, Format, body: untyped): untyped =
-  server.rpcHttpServer.rpc(path, Format, body)
+template rpc*(server: RpcProxy, path: string, flavorType, body: untyped): untyped =
+  server.rpcHttpServer.rpc(path, flavorType, body)
 
 template rpc*(server: RpcProxy, path: string, body: untyped): untyped =
   server.rpcHttpServer.rpc(path, body)

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -42,8 +42,8 @@ template rpc*(server: RpcServer, path: string, formatType, body: untyped): untyp
 template rpc*(server: RpcServer, path: string, body: untyped): untyped =
   server.router.rpc(path, body)
 
-template rpcContext*(server: RpcServer, Format: type SerializationFormat, body: untyped): untyped =
-  server.router.rpcContext(Format, body)
+template rpc*(server: RpcServer, formatType, procList: untyped): untyped =
+  server.router.rpc(formatType, procList)
 
 template hasMethod*(server: RpcServer, methodName: string): bool =
   server.router.hasMethod(methodName)

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -42,6 +42,9 @@ template rpc*(server: RpcServer, path: string, flavorType, body: untyped): untyp
 template rpc*(server: RpcServer, path: string, body: untyped): untyped =
   server.router.rpc(path, body)
 
+template rpcContext*(server: RpcServer, flavor: type SerializationFormat, body: untyped): untyped =
+  server.router.rpcContext(flavor, body)
+
 template hasMethod*(server: RpcServer, methodName: string): bool =
   server.router.hasMethod(methodName)
 

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -56,12 +56,17 @@ proc executeMethod*(server: RpcServer,
 
   processsSingleResponse(respData.toOpenArrayByte(0, respData.high()), 0)
 
-proc executeMethod*(server: RpcServer,
-                    methodName: string,
-                    args: JsonNode): Future[JsonString] {.async: (raises: [CancelledError, JsonRpcError], raw: true).} =
-
-  let params = paramsTx(args)
+proc executeMethod*(
+    server: RpcServer,
+    methodName: string,
+    args: JsonNode,
+    Format: type SerializationFormat
+): Future[JsonString] {.async: (raises: [CancelledError, JsonRpcError], raw: true).} =
+  let params = paramsTx(args, Format)
   server.executeMethod(methodName, params)
+
+template executeMethod*(server: RpcServer, methodName: string, args: JsonNode): untyped =
+  executeMethod(server, methodName, args, JrpcConv)
 
 proc executeMethod*(server: RpcServer,
                     methodName: string,

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -36,14 +36,14 @@ proc new*(T: type RpcServer): T =
 # Public functions
 # ------------------------------------------------------------------------------
 
-template rpc*(server: RpcServer, path: string, flavorType, body: untyped): untyped =
-  server.router.rpc(path, flavorType, body)
+template rpc*(server: RpcServer, path: string, formatType, body: untyped): untyped =
+  server.router.rpc(path, formatType, body)
 
 template rpc*(server: RpcServer, path: string, body: untyped): untyped =
   server.router.rpc(path, body)
 
-template rpcContext*(server: RpcServer, Flavor: type SerializationFormat, body: untyped): untyped =
-  server.router.rpcContext(Flavor, body)
+template rpcContext*(server: RpcServer, Format: type SerializationFormat, body: untyped): untyped =
+  server.router.rpcContext(Format, body)
 
 template hasMethod*(server: RpcServer, methodName: string): bool =
   server.router.hasMethod(methodName)
@@ -60,9 +60,9 @@ proc executeMethod*(server: RpcServer,
   processsSingleResponse(respData.toOpenArrayByte(0, respData.high()), 0)
 
 proc executeMethod*(
-    server: RpcServer, methodName: string, args: JsonNode, Flavor: type SerializationFormat
+    server: RpcServer, methodName: string, args: JsonNode, Format: type SerializationFormat
 ): Future[JsonString] {.async: (raises: [CancelledError, JsonRpcError], raw: true).} =
-  let params = paramsTx(args, Flavor)
+  let params = paramsTx(args, Format)
   server.executeMethod(methodName, params)
 
 proc executeMethod*(

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -36,6 +36,9 @@ proc new*(T: type RpcServer): T =
 # Public functions
 # ------------------------------------------------------------------------------
 
+template rpc*(server: RpcServer, path: string, Format, body: untyped): untyped =
+  server.router.rpc(path, Format, body)
+
 template rpc*(server: RpcServer, path: string, body: untyped): untyped =
   server.router.rpc(path, body)
 

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -57,16 +57,16 @@ proc executeMethod*(server: RpcServer,
   processsSingleResponse(respData.toOpenArrayByte(0, respData.high()), 0)
 
 proc executeMethod*(
-    server: RpcServer,
-    methodName: string,
-    args: JsonNode,
-    Flavor: type SerializationFormat
+    server: RpcServer, methodName: string, args: JsonNode, Flavor: type SerializationFormat
 ): Future[JsonString] {.async: (raises: [CancelledError, JsonRpcError], raw: true).} =
   let params = paramsTx(args, Flavor)
   server.executeMethod(methodName, params)
 
-template executeMethod*(server: RpcServer, methodName: string, args: JsonNode): untyped =
-  executeMethod(server, methodName, args, JrpcConv)
+proc executeMethod*(
+    server: RpcServer, methodName: string, args: JsonNode
+): Future[JsonString] {.async: (raises: [CancelledError, JsonRpcError], raw: true).} =
+  let params = paramsTx(args, JrpcConv)
+  server.executeMethod(methodName, params)
 
 proc executeMethod*(server: RpcServer,
                     methodName: string,

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -42,8 +42,8 @@ template rpc*(server: RpcServer, path: string, flavorType, body: untyped): untyp
 template rpc*(server: RpcServer, path: string, body: untyped): untyped =
   server.router.rpc(path, body)
 
-template rpcContext*(server: RpcServer, flavor: type SerializationFormat, body: untyped): untyped =
-  server.router.rpcContext(flavor, body)
+template rpcContext*(server: RpcServer, Flavor: type SerializationFormat, body: untyped): untyped =
+  server.router.rpcContext(Flavor, body)
 
 template hasMethod*(server: RpcServer, methodName: string): bool =
   server.router.hasMethod(methodName)

--- a/json_rpc/server.nim
+++ b/json_rpc/server.nim
@@ -36,8 +36,8 @@ proc new*(T: type RpcServer): T =
 # Public functions
 # ------------------------------------------------------------------------------
 
-template rpc*(server: RpcServer, path: string, Format, body: untyped): untyped =
-  server.router.rpc(path, Format, body)
+template rpc*(server: RpcServer, path: string, flavorType, body: untyped): untyped =
+  server.router.rpc(path, flavorType, body)
 
 template rpc*(server: RpcServer, path: string, body: untyped): untyped =
   server.router.rpc(path, body)
@@ -60,9 +60,9 @@ proc executeMethod*(
     server: RpcServer,
     methodName: string,
     args: JsonNode,
-    Format: type SerializationFormat
+    Flavor: type SerializationFormat
 ): Future[JsonString] {.async: (raises: [CancelledError, JsonRpcError], raw: true).} =
-  let params = paramsTx(args, Format)
+  let params = paramsTx(args, Flavor)
   server.executeMethod(methodName, params)
 
 template executeMethod*(server: RpcServer, methodName: string, args: JsonNode): untyped =

--- a/tests/private/file_callsigs_flavor.nim
+++ b/tests/private/file_callsigs_flavor.nim
@@ -7,4 +7,4 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-proc getFileFlavor(s: DisString): DisString
+proc getFileFlavor(s: FlavorObj): FlavorObj

--- a/tests/private/file_callsigs_flavor.nim
+++ b/tests/private/file_callsigs_flavor.nim
@@ -1,0 +1,10 @@
+# json-rpc
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+proc getFileFlavor(s: DisString): DisString

--- a/tests/private/flavor.nim
+++ b/tests/private/flavor.nim
@@ -1,0 +1,38 @@
+# json-rpc
+# Copyright (c) 2019-2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  json_serialization, json
+
+type
+  FlavorString* = distinct string
+  FlavorObj* = object
+    s*: FlavorString
+
+proc `==`*(a, b: FlavorString): bool {.borrow.}
+proc `%`*(s: FlavorString): JsonNode {.borrow.}
+
+proc init*(T: type FlavorObj, s: string): FlavorObj =
+  FlavorObj(s: s.FlavorString)
+
+createJsonFlavor JrpcFlavor,
+  automaticObjectSerialization = true,
+  automaticPrimitivesSerialization = true
+
+proc readValue*(
+    reader: var JrpcFlavor.Reader, value: var FlavorString
+) {.gcsafe, raises: [IOError, SerializationError].} =
+  value = reader.readValue(string).FlavorString
+
+proc writeValue*(
+    writer: var JrpcFlavor.Writer, value: FlavorString
+) {.gcsafe, raises: [IOError].} =
+  writer.writeValue value.string

--- a/tests/testproxy.nim
+++ b/tests/testproxy.nim
@@ -34,6 +34,10 @@ template registerMethods(srv: RpcServer, proxy: RpcProxy) =
   proxy.rpc("myProc1Flavor", JrpcFlavor) do(obj: FlavorObj) -> FlavorObj:
     return FlavorObj.init("ret " & obj.s.string)
 
+  proxy.rpcContext(JrpcFlavor):
+    rpc("myProc1FlavorCtx") do(obj: FlavorObj) -> FlavorObj:
+      return FlavorObj.init("ret " & obj.s.string)
+
 suite "Proxy RPC through http":
   var srv = newRpcHttpServer([srvAddress])
   var proxy = RpcProxy.new([proxySrvAddress], getHttpClientConfig("http://" & $srv.localAddress()[0]))
@@ -67,6 +71,10 @@ suite "Proxy RPC through http":
 
   test "Successful RPC call no proxy with flavor":
     let r = waitFor client.call("myProc1Flavor", %[FlavorObj.init("foobar")])
+    check r.string == """{"s":"ret foobar"}"""
+
+  test "Successful RPC call no proxy with flavor context":
+    let r = waitFor client.call("myProc1FlavorCtx", %[FlavorObj.init("foobar")])
     check r.string == """{"s":"ret foobar"}"""
 
   waitFor srv.stop()

--- a/tests/testproxy.nim
+++ b/tests/testproxy.nim
@@ -34,8 +34,8 @@ template registerMethods(srv: RpcServer, proxy: RpcProxy) =
   proxy.rpc("myProc1Flavor", JrpcFlavor) do(obj: FlavorObj) -> FlavorObj:
     return FlavorObj.init("ret " & obj.s.string)
 
-  proxy.rpcContext(JrpcFlavor):
-    rpc("myProc1FlavorCtx") do(obj: FlavorObj) -> FlavorObj:
+  proxy.rpc(JrpcFlavor):
+    proc myProc1FlavorCtx(obj: FlavorObj): FlavorObj =
       return FlavorObj.init("ret " & obj.s.string)
 
 suite "Proxy RPC through http":

--- a/tests/testproxy.nim
+++ b/tests/testproxy.nim
@@ -9,7 +9,9 @@
 
 import
   unittest2, chronicles,
-  ../json_rpc/[rpcclient, rpcserver, rpcproxy]
+  ../json_rpc/[rpcclient, rpcserver, rpcproxy],
+  ./private/helpers,
+  ./private/flavor
 
 let srvAddress = initTAddress("127.0.0.1", Port(0))
 let proxySrvAddress = "127.0.0.1:0"
@@ -23,6 +25,14 @@ template registerMethods(srv: RpcServer, proxy: RpcProxy) =
   # Create standard handler on server
   proxy.rpc("myProc1") do(input: string, data: array[0..3, int]):
     return %("Hello " & input & " data: " & $data)
+
+  srv.rpc("myProcFlavor", JrpcFlavor) do(obj: FlavorObj) -> FlavorObj:
+    return FlavorObj.init("ret " & obj.s.string)
+
+  proxy.registerProxyMethod("myProcFlavor")
+
+  proxy.rpc("myProc1Flavor", JrpcFlavor) do(obj: FlavorObj) -> FlavorObj:
+    return FlavorObj.init("ret " & obj.s.string)
 
 suite "Proxy RPC through http":
   var srv = newRpcHttpServer([srvAddress])
@@ -38,15 +48,26 @@ suite "Proxy RPC through http":
   test "Successful RPC call thorugh proxy":
     let r = waitFor client.call("myProc", %[%"abc", %[1, 2, 3, 4]])
     check r.string == "\"Hello abc data: [1, 2, 3, 4]\""
+
   test "Successful RPC call no proxy":
     let r = waitFor client.call("myProc1", %[%"abc", %[1, 2, 3, 4]])
     check r.string == "\"Hello abc data: [1, 2, 3, 4]\""
+
   test "Missing params":
     expect(CatchableError):
       discard waitFor client.call("myProc", %[%"abc"])
+
   test "Method missing on server and proxy server":
     expect(CatchableError):
       discard waitFor client.call("missingMethod", %[%"abc"])
+
+  test "Successful RPC call thorugh proxy with flavor":
+    let r = waitFor client.call("myProcFlavor", %[FlavorObj.init("foobar")])
+    check r.string == """{"s":"ret foobar"}"""
+
+  test "Successful RPC call no proxy with flavor":
+    let r = waitFor client.call("myProc1Flavor", %[FlavorObj.init("foobar")])
+    check r.string == """{"s":"ret foobar"}"""
 
   waitFor srv.stop()
   waitFor srv.closeWait()
@@ -67,12 +88,15 @@ suite "Proxy RPC through websockets":
   test "Successful RPC call thorugh proxy":
     let r = waitFor client.call("myProc", %[%"abc", %[1, 2, 3, 4]])
     check r.string == "\"Hello abc data: [1, 2, 3, 4]\""
+
   test "Successful RPC call no proxy":
     let r = waitFor client.call("myProc1", %[%"abc", %[1, 2, 3, 4]])
     check r.string == "\"Hello abc data: [1, 2, 3, 4]\""
+
   test "Missing params":
     expect(CatchableError):
       discard waitFor client.call("myProc", %[%"abc"])
+
   test "Method missing on server and proxy server":
     expect(CatchableError):
       discard waitFor client.call("missingMethod", %[%"abc"])

--- a/tests/testrpcmacro.nim
+++ b/tests/testrpcmacro.nim
@@ -12,6 +12,7 @@ import
   chronicles,
   ../json_rpc/rpcserver,
   ./private/helpers,
+  ./private/flavor,
   json_serialization/std/options
 
 type
@@ -126,6 +127,9 @@ s.rpc("rpc.optionalArg2") do(a, b: string, c, d: Option[string]) -> string:
 s.rpc("echo") do(car: MuscleCar) -> JsonString:
   return JrpcConv.encode(car).JsonString
 
+s.rpc("rpc.flavor", JrpcFlavor) do(obj: FlavorObj) -> FlavorObj:
+  return FlavorObj.init("ret " & obj.s.string)
+
 type
   OptionalFields = object
     a: int
@@ -196,6 +200,7 @@ suite "Server types":
     check s.hasMethod("rpc.optionalArgNotBuiltin")
     check s.hasMethod("rpc.optInObj")
     check s.hasMethod("rpc.optionalStringArg")
+    check s.hasMethod("rpc.flavor")
 
   test "Simple paths":
     let r = waitFor s.executeMethod("rpc.simplePath", %[])
@@ -363,6 +368,10 @@ suite "Server types":
 
     let x = waitFor s.executeMethod("echo", """{"car":{"color":null,"wheel":77}}""".JsonString)
     check x == """{"color":"","wheel":77}"""
+
+  test "flavor":
+    let r = waitFor s.executeMethod("rpc.flavor", %[FlavorObj.init("foobar")])
+    check r.string == """{"s":"ret foobar"}"""
 
 s.stop()
 waitFor s.closeWait()

--- a/tests/testrpcmacro.nim
+++ b/tests/testrpcmacro.nim
@@ -370,8 +370,8 @@ suite "Server types":
     check x == """{"color":"","wheel":77}"""
 
   test "flavor":
-    let r = waitFor s.executeMethod("rpc.flavor", %[FlavorObj.init("foobar")])
-    check r.string == """{"s":"ret foobar"}"""
+    let r = waitFor s.executeMethod("rpc.flavor", %[FlavorObj.init("foobar")], JrpcFlavor)
+    check r == """{"s":"ret foobar"}"""
 
 s.stop()
 waitFor s.closeWait()

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -40,6 +40,9 @@ proc setupServer*(srv: RpcServer) =
     proc my_Proc_Ctx4(obj: FlavorObj): FlavorObj =
       return FlavorObj.init("ret " & obj.s.string)
 
+    proc myProcCtx5(obj: FlavorObj) =
+      return %("ret " & obj.s.string)
+
   # A second context in same scope works
   srv.rpc(JrpcFlavor):
     proc myProcCtxOther(obj: FlavorObj): FlavorObj =
@@ -76,12 +79,14 @@ template callTests(client: untyped) =
       r2 = waitFor client.call("myProcCtx2", %[FlavorObj.init("foobar2")], JrpcFlavor)
       r3 = waitFor client.call("my.Proc.Ctx3", %[FlavorObj.init("foobar3")], JrpcFlavor)
       r4 = waitFor client.call("my_Proc_Ctx4", %[FlavorObj.init("foobar4")], JrpcFlavor)
+      r5 = waitFor client.call("myProcCtx5", %[FlavorObj.init("foobar5")], JrpcFlavor)
     check:
       r.string == """{"s":"ret foobar"}"""
       r1.string == """{"s":"ret foobar1"}"""
       r2.string == """{"s":"ret foobar2"}"""
       r3.string == """{"s":"ret foobar3"}"""
       r4.string == """{"s":"ret foobar4"}"""
+      r5.string == """"ret foobar5""""
 
 suite "Socket Server/Client RPC/newLine":
   setup:


### PR DESCRIPTION
Fix #239

Changes:

- Add flavor as last param to client/server APIs.
- Set `JrpcConv` as default flavor for backward compat.
- Add `rpc(server, format, procList)` API to avoid repeating passing the server and flavor params in every rpc.

tested in nimbus-eth1/2, nim-web3; see linked PRs.