### PR TITLE
Make async pragma required in rpc context API

### DIFF
--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -175,8 +175,9 @@ proc rpcImpl(server: NimNode, path: string, formatType, body: NimNode): NimNode 
     params = body.findChild(it.kind == nnkFormalParams)
     procBody = if body.kind == nnkStmtList: body else: body.body
     procWrapper = genSym(nskProc, path & "_rpcWrapper")
+    procPragmas = if body.kind == nnkProcDef: body.pragma else: nil
 
-  result = wrapServerHandler(path, params, procBody, procWrapper, formatType)
+  result = wrapServerHandler(path, params, procBody, procWrapper, procPragmas, formatType)
 
   result.add quote do:
     `server`.register(`path`, `procWrapper`)


### PR DESCRIPTION
This makes async pragma explicit in RPC handlers and allows to define the raises list `{.async: (raises: []).}`. If the RPC is not async, the generated handler is non-async. All pragmas are copied as is into the generated handler in both cases.

Changes:

- RPC functions with async pragma generates async handlers.
- Non-async RPC functions no longer generates async handlers. The handler wrapper is still async; making the wrapper non-async would require adding a routes table for non-async callbacks, this can be done later.

When there are unlisted raises exceptions, the compile error does point to the right function.

No changes in the `srv.rpc("path") do(): ...` API. It still generates async handlers always, and ignores pragmas.

This is non-breaking given there is no release with the new API #259 yet