### PR TITLE
Relax nim-websock version constraint in json_rpc.nimble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
   build:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
     with:
-      nimble-version: 6fe9d817a70a14fa57022a9cca46eb443ee5a040
       test-command: |
         nimble setup -l
         nimble test

--- a/json_rpc.nimble
+++ b/json_rpc.nimble
@@ -24,7 +24,7 @@ requires "nim >= 1.6.0",
          "chronos >= 4.0.3 & < 5.0.0",
          "httputils >= 0.3.0",
          "chronicles",
-         "websock >= 0.2.1 & <= 0.3.0",
+         "websock >= 0.2.1 & < 0.4.0",
          "serialization >= 0.4.4",
          "json_serialization >= 0.4.2",
          "unittest2"

--- a/json_rpc.nimble
+++ b/json_rpc.nimble
@@ -24,7 +24,7 @@ requires "nim >= 1.6.0",
          "chronos >= 4.0.3 & < 5.0.0",
          "httputils >= 0.3.0",
          "chronicles",
-         "websock >= 0.2.1 & < 0.3.0",
+         "websock >= 0.2.1 & <= 0.3.0",
          "serialization >= 0.4.4",
          "json_serialization >= 0.4.2",
          "unittest2"


### PR DESCRIPTION
logos-delivery depends on nim-json-rpc, and nim-json-rpc's `websock < 0.3.0` constraint makes the package tree for logos-delivery unresolvable.

This PR bumps nim-json-rpc's constraint to be inclusive of [nim-websock v0.3.0](https://github.com/status-im/nim-websock/commit/c105d98e6522e0e2cbe3dfa11b07a273e9fd0e7b).

Testing: just in case, I've forced nim-json-rpc to use nim-websock v0.3.0 (with a `>= 0.3.0 & <= 0.3.0` constraint) and `nimble test` passed.