### PR TITLE
Fix custom socket framing to support concurrency

### DIFF
--- a/json_rpc/clients/socketclient.nim
+++ b/json_rpc/clients/socketclient.nim
@@ -77,8 +77,9 @@ proc recvMsgHttpHeader(
 proc sendMsgHttpHeader(
     transport: StreamTransport, msg: seq[byte]
 ) {.async: (raises: [CancelledError, TransportError]).} =
-  discard await transport.write("Content-Length: " & $msg.len & "\r\n\r\n")
-  discard await transport.write(msg)
+  const field = toBytes("Content-Length: ")
+  const separator = toBytes("\r\n\r\n")
+  discard await transport.write(field & toBytes($msg.len) & separator & msg)
 
 proc httpHeader*(T: type Framing): T =
   ## Framing using a HTTP-like `Content-Length: <length>\r\n` header followed by
@@ -146,8 +147,7 @@ proc sendMsgLengthHeaderBE32(
     transport: StreamTransport, msg: seq[byte]
 ) {.async: (raises: [CancelledError, TransportError]).} =
   var header = msg.len.uint32.toBytesBE()
-  discard await transport.write(addr header[0], header.len)
-  discard await transport.write(msg)
+  discard await transport.write(@header & msg)
 
 proc lengthHeaderBE32*(T: type Framing): T =
   ## Framing using a HTTP-like `Content-Length` header followed by two newlines

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -90,7 +90,7 @@ template callTests(client: untyped) =
 
   test "Concurrent RPC calls":
     var calls = newSeq[Future[JsonString]]()
-    for i in 0 ..< 110_000:
+    for i in 0 ..< 11_000:
       calls.add client.call("myProc", %[% $i, %[1, 2, 3, 4]])
     waitFor allFutures(calls)
     for i, r in calls.pairs():

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -89,13 +89,12 @@ template callTests(client: untyped) =
       r5.string == """"ret foobar5""""
 
   test "Concurrent RPC calls":
-    let params = %[%"abc", %[1, 2, 3, 4]]
     var calls = newSeq[Future[JsonString]]()
-    for _ in 0 ..< 100:
-      calls.add client.call("myProc", params)
+    for i in 0 ..< 110_000:
+      calls.add client.call("myProc", %[% $i, %[1, 2, 3, 4]])
     waitFor allFutures(calls)
-    for r in calls:
-      check r.read().string == "\"Hello abc data: [1, 2, 3, 4]\""
+    for i, r in calls.pairs():
+      check r.read().string == "\"Hello " & $i & " data: [1, 2, 3, 4]\""
 
 suite "Socket Server/Client RPC/newLine":
   setup:

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -88,6 +88,15 @@ template callTests(client: untyped) =
       r4.string == """{"s":"ret foobar4"}"""
       r5.string == """"ret foobar5""""
 
+  test "Concurrent RPC calls":
+    let params = %[%"abc", %[1, 2, 3, 4]]
+    var calls = newSeq[Future[JsonString]]()
+    for _ in 0 ..< 100:
+      calls.add client.call("myProc", params)
+    waitFor allFutures(calls)
+    for r in calls:
+      check r.read().string == "\"Hello abc data: [1, 2, 3, 4]\""
+
 suite "Socket Server/Client RPC/newLine":
   setup:
     const framing = Framing.newLine()

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -90,11 +90,15 @@ template callTests(client: untyped) =
 
   test "Concurrent RPC calls":
     var calls = newSeq[Future[JsonString]]()
-    for i in 0 ..< 11_000:
+    for i in 0 ..< 50_000:
       calls.add client.call("myProc", %[% $i, %[1, 2, 3, 4]])
     waitFor allFutures(calls)
     for i, r in calls.pairs():
-      check r.read().string == "\"Hello " & $i & " data: [1, 2, 3, 4]\""
+      let got = r.read().string
+      let expected = "\"Hello " & $i & " data: [1, 2, 3, 4]\""
+      check got == expected
+      if got != expected:
+        break  # one failure is enough
 
 suite "Socket Server/Client RPC/newLine":
   setup:

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -93,12 +93,10 @@ template callTests(client: untyped) =
     for i in 0 ..< 50_000:
       calls.add client.call("myProc", %[% $i, %[1, 2, 3, 4]])
     waitFor allFutures(calls)
+    var checked = 0
     for i, r in calls.pairs():
-      let got = r.read().string
-      let expected = "\"Hello " & $i & " data: [1, 2, 3, 4]\""
-      check got == expected
-      if got != expected:
-        break  # one failure is enough
+      checked += int(r.read().string == "\"Hello " & $i & " data: [1, 2, 3, 4]\"")
+    check calls.len == checked
 
 suite "Socket Server/Client RPC/newLine":
   setup:


### PR DESCRIPTION
Sending data must do one single write, otherwise the writes may interleave when sending concurrently.

It required 50k concurrent calls to reproduce on Linux :/ and only a few to reproduce on Win.