### PR TITLE
Fix #274: Invalid `meth` implementation.

### DIFF
--- a/json_rpc/private/jrpc_sys.nim
+++ b/json_rpc/private/jrpc_sys.nim
@@ -213,8 +213,8 @@ func `==`*(a, b: RequestId): bool =
   of riString: a.str == b.str
   of riNull: true
 
-func meth*(rx: RequestRx): string =
-  rx.`method`.get
+func meth*(rx: RequestRx): Opt[string] =
+  rx.`method`
 
 func meth*(rx: RequestRx2): string =
   rx.`method`

--- a/json_rpc/private/jrpc_sys.nim
+++ b/json_rpc/private/jrpc_sys.nim
@@ -213,7 +213,10 @@ func `==`*(a, b: RequestId): bool =
   of riString: a.str == b.str
   of riNull: true
 
-func meth*(rx: RequestRx | RequestRx2): string =
+func meth*(rx: RequestRx): string =
+  rx.`method`.get
+
+func meth*(rx: RequestRx2): string =
   rx.`method`
 
 template shouldWriteObjectField*(field: RequestParamsTx): bool =

--- a/tests/test_jrpc_sys.nim
+++ b/tests/test_jrpc_sys.nim
@@ -204,3 +204,22 @@ suite "jrpc_sys serialization":
         rx.kind == ResponseKind.rkError
         rx.error.code == tx.error.code
         rx.error.message == tx.error.message
+
+  test "meth helper works for both RequestRx and RequestRx2":
+    # RequestRx2 test: method is a string
+    let rx2 = RequestRx2(
+      jsonrpc: JsonRPC2(),
+      `method`: "test_method",
+      params: RequestParamsRx(kind: rpPositional, positional: @[]),
+      id: Opt.some(RequestId(kind: riNumber, num: 42))
+    )
+    check meth(rx2) == "test_method"
+
+    # RequestRx test: method is Opt[string]
+    let rx = RequestRx(
+      jsonrpc: Opt.some(JsonRPC2()),
+      `method`: Opt.some("old_method"),
+      params: RequestParamsRx(kind: rpPositional, positional: @[]),
+      id: RequestId(kind: riNumber, num: 123)
+    )
+    check meth(rx) == "old_method"

--- a/tests/test_jrpc_sys.nim
+++ b/tests/test_jrpc_sys.nim
@@ -222,4 +222,4 @@ suite "jrpc_sys serialization":
       params: RequestParamsRx(kind: rpPositional, positional: @[]),
       id: RequestId(kind: riNumber, num: 123)
     )
-    check meth(rx) == "old_method"
+    check meth(rx).get == "old_method"


### PR DESCRIPTION
Split `meth` into to funcs: one for RequestRx and one for RequestRx2.