### PR TITLE
chore: relax nim-websock cap to allow v0.4.0

### DIFF
--- a/json_rpc.nimble
+++ b/json_rpc.nimble
@@ -24,7 +24,7 @@ requires "nim >= 1.6.0",
          "chronos >= 4.0.3 & < 5.0.0",
          "httputils >= 0.3.0",
          "chronicles",
-         "websock >= 0.2.1 & < 0.4.0",
+         "websock >= 0.2.1 & < 0.5.0",
          "serialization >= 0.4.4",
          "json_serialization >= 0.4.2",
          "unittest2"


### PR DESCRIPTION
PR #269 raised the cap to `< 0.4.0` on Apr 11 2026 -- before
nim-websock v0.4.0 was released (May 13 2026). The cap was a
conservative pin from "latest websock at time of writing", not a
known incompatibility.

Verified locally: with `websock == 0.4.0` forced, all 196 nim-json-rpc
tests pass on both refc and orc backends. nim-websock v0.4.0's API
changes (PR #194 "make rng agnostic") add an `rng` parameter to
`WebSocket.connect()` with a default value, so existing call sites
in clients/websocketclient.nim still compile. The internal `accept`
refactor (acceptStream extraction) preserves the public proc
signature used by servers/websocketserver.nim.

This unblocks downstream consumers (e.g. waku via nim-libp2p v2.0.0)
that require `websock >= 0.4.0`.