### PR TITLE
Support notification in rpc context for non-async method

### DIFF
--- a/json_rpc/private/server_handler_wrapper.nim
+++ b/json_rpc/private/server_handler_wrapper.nim
@@ -345,6 +345,7 @@ func wrapServerHandler*(
 
   let
     executeCall = newCall(handlerName, executeParams)
+    executeCallReturnType = handler.params[0]
 
   result = newStmtList()
   result.add handler
@@ -353,7 +354,7 @@ func wrapServerHandler*(
       # Avoid 'yield in expr not lowered' with an intermediate variable.
       # See: https://github.com/nim-lang/Nim/issues/17849
       `setup`
-      when typeof(`executeCall`) is void:
+      when `executeCallReturnType` is void:
         `executeCall`
       else:
         let handlerRes = `executeCall`

--- a/json_rpc/private/server_handler_wrapper.nim
+++ b/json_rpc/private/server_handler_wrapper.nim
@@ -353,5 +353,8 @@ func wrapServerHandler*(
       # Avoid 'yield in expr not lowered' with an intermediate variable.
       # See: https://github.com/nim-lang/Nim/issues/17849
       `setup`
-      let handlerRes = `executeCall`
-      maybeWrapServerResult(`formatType`, handlerRes)
+      when typeof(`executeCall`) is void:
+        `executeCall`
+      else:
+        let handlerRes = `executeCall`
+        maybeWrapServerResult(`formatType`, handlerRes)

--- a/json_rpc/private/server_handler_wrapper.nim
+++ b/json_rpc/private/server_handler_wrapper.nim
@@ -345,7 +345,7 @@ func wrapServerHandler*(
 
   let
     executeCall = newCall(handlerName, executeParams)
-    executeCallReturnType = handler.params[0]
+    handlerReturnType = handler.params[0]
 
   result = newStmtList()
   result.add handler
@@ -354,7 +354,7 @@ func wrapServerHandler*(
       # Avoid 'yield in expr not lowered' with an intermediate variable.
       # See: https://github.com/nim-lang/Nim/issues/17849
       `setup`
-      when `executeCallReturnType` is void:
+      when `handlerReturnType` is void:
         `executeCall`
       else:
         let handlerRes = `executeCall`

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -206,19 +206,32 @@ template notifyTest(router, client: untyped) =
     var
       notified = newAsyncEvent()
       notified2 = newAsyncEvent()
+      notified3 = newAsyncEvent()
+      notified4 = newAsyncEvent()
 
     router[].rpc("some_notify") do() -> void:
       notified.fire()
     router[].rpc("some_notify2") do() -> void:
       notified2.fire()
 
+    router[].rpc(JrpcFlavor):
+      proc some_notify3(): void =
+        notified3.fire()
+
+      proc some_notify4(): void {.async: (raises: []).} =
+        notified4.fire()
+
     await srv.notify("some_notify", default(RequestParamsTx))
     await srv.notify("doesnt_exist", default(RequestParamsTx))
     await srv.notify("some_notify2", default(RequestParamsTx))
+    await srv.notify("some_notify3", default(RequestParamsTx))
+    await srv.notify("some_notify4", default(RequestParamsTx))
 
     check:
       await notified.wait().withTimeout(1.seconds)
       await notified2.wait().withTimeout(1.seconds)
+      await notified3.wait().withTimeout(1.seconds)
+      await notified4.wait().withTimeout(1.seconds)
 
 suite "Socket Bidirectional":
   setup:


### PR DESCRIPTION
Make this compile:

```nim
srv.rpc(JrpcConv):
  proc empty(): void =
    echo "nothing"
```

void is required because rpc context inherited the implicit `JsonNode` return from the `do` notation API. This PR change is needed regardless.

This is for notifications; still fails for regular requests, same as the `do` notation, see #280

The `do` notation and async variants compile and work as expected.