### PR TITLE
Fix #280; Result of method returning `void` fails to parse

### DIFF
--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -52,7 +52,12 @@ func setupConversion(reqParams, params, formatType: NimNode): NimNode =
 
 template maybeUnwrapClientResult*(client, meth, reqParams, returnType, formatType): auto =
   ## Don't decode e.g. JsonString, return as is
-  when noWrap(returnType):
+  when returnType is void:
+    proc complete(f: auto): Future[returnType] {.async.} =
+      discard await f
+    let fut = client.call(meth, reqParams)
+    complete(fut)
+  elif noWrap(returnType):
     client.call(meth, reqParams)
   else:
     proc complete(f: auto): Future[returnType] {.async: (raises: [CancelledError, JsonRpcError]).} =

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -53,7 +53,7 @@ func setupConversion(reqParams, params, formatType: NimNode): NimNode =
 template maybeUnwrapClientResult*(client, meth, reqParams, returnType, formatType): auto =
   ## Don't decode e.g. JsonString, return as is
   when returnType is void:
-    proc complete(f: auto): Future[returnType] {.async.} =
+    proc complete(f: auto): Future[returnType] {.async: (raises: [CancelledError, JsonRpcError]).} =
       discard await f
     let fut = client.call(meth, reqParams)
     complete(fut)

--- a/json_rpc/private/server_handler_wrapper.nim
+++ b/json_rpc/private/server_handler_wrapper.nim
@@ -239,19 +239,22 @@ func setupNamed(paramsObj, paramsIdent, params, formatType: NimNode): NimNode =
 
 template maybeWrapServerResult*(Format, handlerRes): auto =
   ## Don't encode e.g. JsonString, return as is
-  when typeof(handlerRes) is FutureBase:
-    type ResType = typeof(await handlerRes)
-    when noWrap(ResType):
-      await handlerRes
+  const isFuture = typeof(handlerRes) is FutureBase
+  template awaitMaybe(ret: untyped): untyped =
+    when isFuture:
+      await ret
     else:
-      let res = await handlerRes
-      JsonString(encode(Format, res))
+      ret
+
+  type ResType = typeof(awaitMaybe handlerRes)
+  when ResType is void:
+    awaitMaybe handlerRes
+    JsonString("null")
+  elif noWrap(ResType):
+    awaitMaybe handlerRes
   else:
-    type ResType = typeof(handlerRes)
-    when noWrap(ResType):
-      handlerRes
-    else:
-      JsonString(encode(Format, handlerRes))
+    let res = awaitMaybe handlerRes
+    JsonString(encode(Format, res))
 
 func wrapServerHandler*(
     methName: string, params, procBody, procWrapper, procPragmas, formatType: NimNode

--- a/json_rpc/private/server_handler_wrapper.nim
+++ b/json_rpc/private/server_handler_wrapper.nim
@@ -359,6 +359,7 @@ func wrapServerHandler*(
       `setup`
       when `handlerReturnType` is void:
         `executeCall`
+        JsonString("null")
       else:
         let handlerRes = `executeCall`
         maybeWrapServerResult(`formatType`, handlerRes)

--- a/tests/test_callsigs.nim
+++ b/tests/test_callsigs.nim
@@ -43,6 +43,7 @@ createRpcSigsFromNim(RpcClient):
   proc getVariant(id: Variant): bool
   proc getRefObject(shouldNull: bool): RefObject
   proc wrongResult(): int
+  proc empty(): void
 
 proc installHandlers(s: RpcServer) =
   s.rpc("shh_uninstallFilter") do(id: int) -> bool:
@@ -95,6 +96,9 @@ proc installHandlers(s: RpcServer) =
   s.rpc("wrongResult") do() -> JsonString:
     JsonString("\"bad_value\"")
 
+  s.rpc("empty") do() -> void:
+    discard
+
 suite "test callsigs":
   setup:
     var server = newRpcSocketServer(["127.0.0.1:0"])
@@ -130,6 +134,8 @@ suite "test callsigs":
       check res4 == true
 
   test "callsigs from nim":
+    waitFor client.empty()
+
     let res = waitFor client.get_Banana(789)
     check res == true
 

--- a/tests/test_router_rpc.nim
+++ b/tests/test_router_rpc.nim
@@ -93,8 +93,8 @@ server.rpc(JrpcConv):
   proc rpcCtxAsyncEmpty(s: string): void {.async.} =
     discard
 
-#  proc rpcCtxSyncEmpty(s: string): void =
-#    discard
+  proc rpcCtxSyncEmpty(s: string): void =
+    discard
 
 func req(meth: string, params: string): string =
   """{"jsonrpc":"2.0", "method": """ &
@@ -270,7 +270,7 @@ suite "rpc context":
     let res = waitFor server.route(n)
     check res == """{"jsonrpc":"2.0","result":null,"id":0}"""
 
-#  test "Rpc sync empty response":
-#    let n = req("rpcCtxSyncEmpty", """{"result": "foo"}""")
-#    let res = waitFor server.route(n)
-#    check res == """{"jsonrpc":"2.0","result":null,"id":0}"""
+  test "Rpc sync empty response":
+    let n = req("rpcCtxSyncEmpty", """{"result": "foo"}""")
+    let res = waitFor server.route(n)
+    check res == """{"jsonrpc":"2.0","result":null,"id":0}"""

--- a/tests/test_router_rpc.nim
+++ b/tests/test_router_rpc.nim
@@ -66,6 +66,9 @@ server.rpc("returnJsonString") do(a, b, c: int) -> JsonString:
 server.rpc("serializedFN") do(a{.serializedFieldName: "result".}: int) -> int:
   return a
 
+server.rpc("empty") do() -> void:
+  discard
+
 server.rpc(JrpcConv):
   proc rpcCtxAsync(s: string): string {.async.} =
     await noCancel sleepAsync(0)
@@ -86,6 +89,12 @@ server.rpc(JrpcConv):
 
   proc rpcCtxSyncWithRaises(s: string): string {.raises: [ValueError].} =
     raise (ref ValueError)(msg: "err")
+
+  proc rpcCtxAsyncEmpty(s: string): void {.async.} =
+    discard
+
+#  proc rpcCtxSyncEmpty(s: string): void =
+#    discard
 
 func req(meth: string, params: string): string =
   """{"jsonrpc":"2.0", "method": """ &
@@ -195,6 +204,11 @@ suite "rpc router":
     let res = waitFor server.route(n)
     check res == """[{"jsonrpc":"2.0","result":777,"id":0}]"""
 
+  test "Empty response":
+    let n = req("empty", """{"result": "foo"}""")
+    let res = waitFor server.route(n)
+    check res == """{"jsonrpc":"2.0","result":null,"id":0}"""
+
 suite "rpc context":
   test "Rpc method async":
     let n = req("rpcCtxAsync", """{"s": "foo"}""")
@@ -250,3 +264,13 @@ suite "rpc context":
           return "ret1 " & s
 
     check not compiles(ctxWithAwait())
+
+  test "Rpc async empty response":
+    let n = req("rpcCtxAsyncEmpty", """{"result": "foo"}""")
+    let res = waitFor server.route(n)
+    check res == """{"jsonrpc":"2.0","result":null,"id":0}"""
+
+#  test "Rpc sync empty response":
+#    let n = req("rpcCtxSyncEmpty", """{"result": "foo"}""")
+#    let res = waitFor server.route(n)
+#    check res == """{"jsonrpc":"2.0","result":null,"id":0}"""

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -16,7 +16,7 @@ import
 # Create RPC on server
 proc setupServer*(srv: RpcServer) =
   srv.rpc("myProc") do(input: string, data: array[0..3, int]):
-    return %("Hello " & input & " data: " & $data)
+    %("Hello " & input & " data: " & $data)
 
   srv.rpc("myError") do(input: string, data: array[0..3, int]):
     raise (ref ValueError)(msg: "someMessage")
@@ -25,28 +25,31 @@ proc setupServer*(srv: RpcServer) =
     raise (ref InvalidRequest)(code: -32001, msg: "Unknown payload")
 
   srv.rpc("myProcFlavor", JrpcFlavor) do(obj: FlavorObj) -> FlavorObj:
-    return FlavorObj.init("ret " & obj.s.string)
+    FlavorObj.init("ret " & obj.s.string)
 
   srv.rpc(JrpcFlavor):
     proc myProcCtx1(obj: FlavorObj): FlavorObj =
-      return FlavorObj.init("ret " & obj.s.string)
+      FlavorObj.init("ret " & obj.s.string)
 
     proc myProcCtx2(obj: FlavorObj): FlavorObj =
-      return FlavorObj.init("ret " & obj.s.string)
+      FlavorObj.init("ret " & obj.s.string)
 
     proc `my.Proc.Ctx3`(obj: FlavorObj): FlavorObj =
-      return FlavorObj.init("ret " & obj.s.string)
+      FlavorObj.init("ret " & obj.s.string)
 
     proc my_Proc_Ctx4(obj: FlavorObj): FlavorObj =
-      return FlavorObj.init("ret " & obj.s.string)
+      FlavorObj.init("ret " & obj.s.string)
 
     proc myProcCtx5(obj: FlavorObj) =
-      return %("ret " & obj.s.string)
+      %("ret " & obj.s.string)
+
+    proc myProcCtx6Empty(obj: FlavorObj): void =
+      discard
 
   # A second context in same scope works
   srv.rpc(JrpcFlavor):
     proc myProcCtxOther(obj: FlavorObj): FlavorObj =
-      return FlavorObj.init("ret " & obj.s.string)
+      FlavorObj.init("ret " & obj.s.string)
 
 template callTests(client: untyped) =
   test "Successful RPC call":
@@ -80,6 +83,7 @@ template callTests(client: untyped) =
       r3 = waitFor client.call("my.Proc.Ctx3", %[FlavorObj.init("foobar3")], JrpcFlavor)
       r4 = waitFor client.call("my_Proc_Ctx4", %[FlavorObj.init("foobar4")], JrpcFlavor)
       r5 = waitFor client.call("myProcCtx5", %[FlavorObj.init("foobar5")], JrpcFlavor)
+      r6 = waitFor client.call("myProcCtx6Empty", %[FlavorObj.init("foobar6")], JrpcFlavor)
     check:
       r.string == """{"s":"ret foobar"}"""
       r1.string == """{"s":"ret foobar1"}"""
@@ -87,6 +91,7 @@ template callTests(client: untyped) =
       r3.string == """{"s":"ret foobar3"}"""
       r4.string == """{"s":"ret foobar4"}"""
       r5.string == """"ret foobar5""""
+      r6.string == """null"""
 
   test "Concurrent RPC calls":
     var calls = newSeq[Future[JsonString]]()


### PR DESCRIPTION
Fix #280

Changes:

- Return `result: null` when server rpc method return type is `void`
- Fix client dsl to support rpc method returning `void`
