### PR TITLE
Restrict client raises to `JsonRpcError`

### DIFF
--- a/json_rpc/client.nim
+++ b/json_rpc/client.nim
@@ -29,7 +29,7 @@ import
 from strutils import replace
 
 export
-  chronos, deques, tables, jsonmarshal, RequestParamsTx, RequestIdKind,
+  chronos, deques, tables, errors, jsonmarshal, RequestParamsTx, RequestIdKind,
   RequestId, RequestTx, RequestParamKind, ResponseBatchRx, results
 
 logScope:

--- a/json_rpc/errors.nim
+++ b/json_rpc/errors.nim
@@ -44,7 +44,7 @@ type
 
   ResultDecodeError* = object of JsonRpcError
     ## raised when failing to decode the response result
-    res*: JsonString
+    result*: JsonString
 
   ApplicationError* = object of JsonRpcError
     ## Error to be raised by the application request handlers when the server

--- a/json_rpc/errors.nim
+++ b/json_rpc/errors.nim
@@ -42,6 +42,10 @@ type
     ## raised when fail to decode RequestRx
     payload*: seq[byte]
 
+  ResultDecodeError* = object of JsonRpcError
+    ## raised when failing to decode the response result
+    result*: JsonString
+
   ApplicationError* = object of JsonRpcError
     ## Error to be raised by the application request handlers when the server
     ## needs to respond with a custom application error. The error code should

--- a/json_rpc/errors.nim
+++ b/json_rpc/errors.nim
@@ -44,7 +44,7 @@ type
 
   ResultDecodeError* = object of JsonRpcError
     ## raised when failing to decode the response result
-    result*: JsonString
+    res*: JsonString
 
   ApplicationError* = object of JsonRpcError
     ## Error to be raised by the application request handlers when the server

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -20,7 +20,8 @@ func createRpcProc(procName, parameters, callBody: NimNode): NimNode =
   for p in parameters: paramList.add(p)
 
   # build proc
-  result = newProc(procName, paramList, callBody)
+  let pragmas = quote do: {.async: (raw: true, raises: [CancelledError, JsonRpcError]).}
+  result = newProc(procName, paramList, callBody, pragmas = pragmas)
 
   # export this proc
   result[0] = nnkPostfix.newTree(ident"*", newIdentNode($procName))
@@ -59,8 +60,8 @@ template maybeUnwrapClientResult*(client, meth, reqParams, returnType, formatTyp
       try:
         decode(formatType, res.string, returnType)
       except SerializationError as exc:
-        raise (ref JsonRpcError)(
-          msg: exc.formatMsg("result"), parent: exc
+        raise (ref ResultDecodeError)(
+          result: res, msg: exc.formatMsg("result"), parent: exc
         )
 
     let fut = client.call(meth, reqParams)

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -61,7 +61,7 @@ template maybeUnwrapClientResult*(client, meth, reqParams, returnType, formatTyp
         decode(formatType, res.string, returnType)
       except SerializationError as exc:
         raise (ref ResultDecodeError)(
-          res: res, msg: exc.formatMsg("result"), parent: exc
+          result: res, msg: exc.formatMsg("result"), parent: exc
         )
 
     let fut = client.call(meth, reqParams)

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -60,7 +60,7 @@ template maybeUnwrapClientResult*(client, meth, reqParams, returnType, formatTyp
         decode(formatType, res.string, returnType)
       except SerializationError as exc:
         raise (ref JsonRpcError)(
-          msg: exc.formatMsg("msg"), parent: exc
+          msg: exc.formatMsg("result"), parent: exc
         )
 
     let fut = client.call(meth, reqParams)

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -54,9 +54,15 @@ template maybeUnwrapClientResult*(client, meth, reqParams, returnType, formatTyp
   when noWrap(returnType):
     client.call(meth, reqParams)
   else:
-    proc complete(f: auto): Future[returnType] {.async.} =
+    proc complete(f: auto): Future[returnType] {.async: (raises: [CancelledError, JsonRpcError]).} =
       let res = await f
-      decode(formatType, res.string, returnType)
+      try:
+        decode(formatType, res.string, returnType)
+      except SerializationError as exc:
+        raise (ref JsonRpcError)(
+          msg: exc.formatMsg("msg"), parent: exc
+        )
+
     let fut = client.call(meth, reqParams)
     complete(fut)
 

--- a/json_rpc/private/client_handler_wrapper.nim
+++ b/json_rpc/private/client_handler_wrapper.nim
@@ -61,7 +61,7 @@ template maybeUnwrapClientResult*(client, meth, reqParams, returnType, formatTyp
         decode(formatType, res.string, returnType)
       except SerializationError as exc:
         raise (ref ResultDecodeError)(
-          result: res, msg: exc.formatMsg("result"), parent: exc
+          res: res, msg: exc.formatMsg("result"), parent: exc
         )
 
     let fut = client.call(meth, reqParams)

--- a/tests/test_callsigs.nim
+++ b/tests/test_callsigs.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   unittest2,
   ../json_rpc/rpcclient,

--- a/tests/test_callsigs.nim
+++ b/tests/test_callsigs.nim
@@ -40,6 +40,7 @@ createRpcSigsFromNim(RpcClient):
   proc getJsonString(name: string): JsonString
   proc getVariant(id: Variant): bool
   proc getRefObject(shouldNull: bool): RefObject
+  proc wrongResult(): int
 
 proc installHandlers(s: RpcServer) =
   s.rpc("shh_uninstallFilter") do(id: int) -> bool:
@@ -88,6 +89,9 @@ proc installHandlers(s: RpcServer) =
   s.rpc("getRefObject") do(shouldNull: bool) -> Refobject:
     if shouldNull: return nil
     return RefObject(name: "meow")
+
+  s.rpc("wrongResult") do() -> JsonString:
+    JsonString("\"bad_value\"")
 
 suite "test callsigs":
   setup:
@@ -154,10 +158,20 @@ suite "test callsigs":
     check res2.isNil.not
     check res2.name == "meow"
 
-  test "callsigs from nim with raises":
+  test "callsigs with raises":
     proc testRaises(c: RpcClient) {.async: (raises: [CancelledError, JsonRpcError]).} =
       discard await c.get_Banana(789)
     waitFor testRaises(client)
+
+  test "callsigs with bad result":
+    try:
+      discard waitFor client.wrongResult()
+      fail()
+    except ResultDecodeError as exc:
+      check:
+        exc.result == JsonString("\"bad_value\"")
+        exc.msg == "result(1, 1) number expected"
+        exc.parent of SerializationError
 
 createRpcSigs(RpcClient, sourceDir & "/private/file_callsigs_flavor.nim", JrpcFlavor)
 

--- a/tests/test_callsigs.nim
+++ b/tests/test_callsigs.nim
@@ -169,7 +169,7 @@ suite "test callsigs":
       fail()
     except ResultDecodeError as exc:
       check:
-        exc.res == JsonString("\"bad_value\"")
+        exc.result == JsonString("\"bad_value\"")
         exc.msg == "result(1, 1) number expected"
         exc.parent of SerializationError
 

--- a/tests/test_callsigs.nim
+++ b/tests/test_callsigs.nim
@@ -156,7 +156,7 @@ suite "test callsigs":
 
   test "callsigs from nim with raises":
     proc testRaises(c: RpcClient) {.async: (raises: [CancelledError, JsonRpcError]).} =
-      discard await client.get_Banana(789)
+      discard await c.get_Banana(789)
     waitFor testRaises(client)
 
 createRpcSigs(RpcClient, sourceDir & "/private/file_callsigs_flavor.nim", JrpcFlavor)

--- a/tests/test_callsigs.nim
+++ b/tests/test_callsigs.nim
@@ -90,12 +90,17 @@ proc installHandlers(s: RpcServer) =
     return RefObject(name: "meow")
 
 suite "test callsigs":
-  var server = newRpcSocketServer(["127.0.0.1:0"])
-  server.installHandlers()
-  var client = newRpcSocketClient()
+  setup:
+    var server = newRpcSocketServer(["127.0.0.1:0"])
+    server.installHandlers()
+    var client = newRpcSocketClient()
 
-  server.start()
-  waitFor client.connect(server.localAddress()[0])
+    server.start()
+    waitFor client.connect(server.localAddress()[0])
+
+  teardown:
+    server.stop()
+    waitFor server.closeWait()
 
   test "callsigs from file":
     let res = waitFor client.shh_uninstallFilter(123)
@@ -149,8 +154,10 @@ suite "test callsigs":
     check res2.isNil.not
     check res2.name == "meow"
 
-  server.stop()
-  waitFor server.closeWait()
+  test "callsigs from nim with raises":
+    proc testRaises(c: RpcClient) {.async: (raises: [CancelledError, JsonRpcError]).} =
+      discard await client.get_Banana(789)
+    waitFor testRaises(client)
 
 createRpcSigs(RpcClient, sourceDir & "/private/file_callsigs_flavor.nim", JrpcFlavor)
 
@@ -171,12 +178,17 @@ proc installFlavorHandlers(s: RpcServer) =
     return FlavorObj.init("ret " & obj.s.string)
 
 suite "test callsigs with flavors":
-  var server = newRpcSocketServer(["127.0.0.1:0"])
-  server.installFlavorHandlers()
-  var client = newRpcSocketClient()
+  setup:
+    var server = newRpcSocketServer(["127.0.0.1:0"])
+    server.installFlavorHandlers()
+    var client = newRpcSocketClient()
 
-  server.start()
-  waitFor client.connect(server.localAddress()[0])
+    server.start()
+    waitFor client.connect(server.localAddress()[0])
+
+  teardown:
+    server.stop()
+    waitFor server.closeWait()
 
   test "callsigs from file with flavor":
     let res = waitFor client.getFileFlavor(FlavorObj.init("file"))
@@ -189,6 +201,3 @@ suite "test callsigs with flavors":
   test "callsigs from nim with flavor":
     let res = waitFor client.getNimFlavor(FlavorObj.init("nim"))
     check res == FlavorObj.init("ret nim")
-
-  server.stop()
-  waitFor server.closeWait()

--- a/tests/test_callsigs.nim
+++ b/tests/test_callsigs.nim
@@ -169,7 +169,7 @@ suite "test callsigs":
       fail()
     except ResultDecodeError as exc:
       check:
-        exc.result == JsonString("\"bad_value\"")
+        exc.res == JsonString("\"bad_value\"")
         exc.msg == "result(1, 1) number expected"
         exc.parent of SerializationError
 


### PR DESCRIPTION
Changes:

- Annotate client dsl wrapper with `raises: [CancelledError, JsonRpcError]` to avoid fallback to `CatchableError`.
- Export `errors` in client due to dsl requiring `JsonRpcError`
- Add `ResultDecodeError` to raise it when failing to decode the response result.
- Use `setup` and `teardown` in `test_callsigs`