### PR TITLE
fix(websocket): do not swallow cancellations

### DIFF
--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -84,6 +84,8 @@ method request(
   client.withPendingFut(fut, id):
     try:
       await transport.send(reqData, Opcode.Binary)
+    except CancelledError as exc:
+      raise exc
     except CatchableError as exc:
       raise (ref RpcPostError)(msg: exc.msg, parent: exc)
 


### PR DESCRIPTION
Websocket client requests do not handle cancellation properly; they wrap a `CancelledError` in an `RpcPostError`.
Any code that uses websocket requests can therefore no longer be cancelled properly.

This change fixes the issue.