### PR TITLE
Fix #285; Do not swallow cancellations in socket client

### DIFF
--- a/json_rpc/clients/socketclient.nim
+++ b/json_rpc/clients/socketclient.nim
@@ -211,7 +211,7 @@ method request(
   client.withPendingFut(fut, id):
     try:
       await client.framing.sendMsg(client.transport, reqData)
-    except CatchableError as exc:
+    except TransportError as exc:
       raise (ref RpcPostError)(msg: exc.msg, parent: exc)
 
     await fut

--- a/json_rpc/clients/websocketclient.nim
+++ b/json_rpc/clients/websocketclient.nim
@@ -116,6 +116,8 @@ proc processMessages(client: RpcWebSocketClient) {.async: (raises: []).} =
       except JsonRpcError as exc:
         try:
           await client.transport.send(wrapError(router.INVALID_REQUEST, exc.msg), Opcode.Binary)
+        except CancelledError as e:
+          raise e
         except CatchableError:
           discard
         raise exc

--- a/json_rpc/private/server_handler_wrapper.nim
+++ b/json_rpc/private/server_handler_wrapper.nim
@@ -48,7 +48,7 @@ func unpackArg(args: JsonString, argName: string, argType: type, Format: type Se
   ## Nim data types
   try:
     result = decode(Format, args.string, argType)
-  except CatchableError as err:
+  except SerializationError as err:
     raise newException(RequestDecodeError,
       "Parameter [" & argName & "] of type '" &
       $argType & "' could not be decoded: " & err.msg)


### PR DESCRIPTION
Fix #285

Unlikely to be breaking given CancelledError is usually propagated anyway (in await fut, instead of the send call).